### PR TITLE
added option to specify a project for the dns zone

### DIFF
--- a/primary.tf
+++ b/primary.tf
@@ -57,6 +57,7 @@ resource "google_compute_instance" "primary" {
 
 data "google_dns_managed_zone" "dnszone" {
   name = "${var.dns_zone}"
+  project = "${var.dns_project == "" ? "${var.project}" : var.dns_project}"
 }
 
 resource "google_dns_record_set" "primarydns" {
@@ -64,6 +65,7 @@ resource "google_dns_record_set" "primarydns" {
   name  = "${var.prefix}-primary-${count.index}.${data.google_dns_managed_zone.dnszone.dns_name}"
   type  = "A"
   ttl   = 300
+  project = "${var.dns_project == "" ? "${var.project}" : var.dns_project}"
 
   managed_zone = "${data.google_dns_managed_zone.dnszone.name}"
 

--- a/primary.tf
+++ b/primary.tf
@@ -57,7 +57,7 @@ resource "google_compute_instance" "primary" {
 
 data "google_dns_managed_zone" "dnszone" {
   name = "${var.dns_zone}"
-  project = "${var.dns_project == "" ? "${var.project}" : var.dns_project}"
+  project = "${var.dns_project == "" ? var.project : var.dns_project}"
 }
 
 resource "google_dns_record_set" "primarydns" {
@@ -65,7 +65,7 @@ resource "google_dns_record_set" "primarydns" {
   name  = "${var.prefix}-primary-${count.index}.${data.google_dns_managed_zone.dnszone.dns_name}"
   type  = "A"
   ttl   = 300
-  project = "${var.dns_project == "" ? "${var.project}" : var.dns_project}"
+  project = "${var.dns_project == "" ? var.project : var.dns_project}"
 
   managed_zone = "${data.google_dns_managed_zone.dnszone.name}"
 

--- a/variables.tf
+++ b/variables.tf
@@ -213,6 +213,12 @@ variable "zone" {
   default     = "us-central1-a"
 }
 
+variable "dns_project" {
+  type        = "string"
+  description = "Name of project where the DNS zone resides"
+  default     = ""
+}
+
 ###################################################
 # Resources
 ###################################################


### PR DESCRIPTION
Optional variable added 'dns_project' which, if specified, will override the default project for the google_dns_managed_zone data source and the google_dns_record_set resource for creading dns entries for the primary instances.