### PR TITLE
Primary nodes

### DIFF
--- a/primary.tf
+++ b/primary.tf
@@ -1,5 +1,5 @@
 resource "google_compute_instance" "primary" {
-  count        = "${var.primary_count}"
+  count        = "3"
   name         = "${var.prefix}-primary-${count.index}"
   machine_type = "${var.primary_machine_type}"
   zone         = "${var.zone}"

--- a/primary.tf
+++ b/primary.tf
@@ -1,5 +1,5 @@
 resource "google_compute_instance" "primary" {
-  count        = "3"
+  count        = "${var.install_type == "ipm" ? 3 : var.primary_count}"
   name         = "${var.prefix}-primary-${count.index}"
   machine_type = "${var.primary_machine_type}"
   zone         = "${var.zone}"

--- a/primary.tf
+++ b/primary.tf
@@ -1,4 +1,7 @@
 resource "google_compute_instance" "primary" {
+  /* The number of primaries must be hard coded to 3 when Internal Production Mode
+  is selected. Currently, that mode does not support scaling. In other modes, the 
+  cluster can be scaled according the primary_count variable. */
   count        = "${var.install_type == "ipm" ? 3 : var.primary_count}"
   name         = "${var.prefix}-primary-${count.index}"
   machine_type = "${var.primary_machine_type}"

--- a/secondary.tf
+++ b/secondary.tf
@@ -16,7 +16,6 @@ resource "google_compute_region_instance_group_manager" "secondary" {
 
   base_instance_name = "${var.prefix}-secondary"
   instance_template  = "${module.instance-template.secondary_template}"
-  update_strategy    = "NONE"
   region             = "${var.region}"
 
   target_size = "${var.secondary_count}"

--- a/variables.tf
+++ b/variables.tf
@@ -167,8 +167,8 @@ variable "image_family" {
 
 variable "primary_count" {
   type        = "string"
-  description = "Number of primary nodes to run, must be odd number"
-  default     = "1"
+  description = "Currently unused. Must have 3 primary nodes."
+  default     = "3"
 }
 
 variable "prefix" {

--- a/variables.tf
+++ b/variables.tf
@@ -167,7 +167,7 @@ variable "image_family" {
 
 variable "primary_count" {
   type        = "string"
-  description = "Currently unused. Must have 3 primary nodes."
+  description = "Number of primary nodes to run, must be odd number - 3 or 5 recommended."
   default     = "3"
 }
 


### PR DESCRIPTION
Force 3 primary nodes if mode is internal production, due to scaling issue with ceph, otherwise use count value.