### PR TITLE
Fix Custom CA bundle install, rename ca_cert_url to ca_bundle_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Please contact your Technical Account Manager for more information, and support 
 | ssl\_policy | SSL policy for the cert | string | n/a | yes |
 | subnet | name of the subnet to install into | string | n/a | yes |
 | airgap\_installer\_url | URL to replicated's airgap installer package | string | `"https://install.terraform.io/installer/replicated-v5.tar.gz"` | no |
-| ca_cert_url | URL to CA certificate file used for the internal `ptfe-proxy` used for outgoing connections| string | `"none"` | no |
+| ca_bundle_url | URL to CA certificate file used for the internal `ptfe-proxy` used for outgoing connections| string | `"none"` | no |
 | airgap\_package\_url | airgap url | string | `"none"` | no |
 | boot\_disk\_size | The size of the boot disk to use for the instances | string | `"40"` | no |
 | encryption\_password | encryption password for the vault unseal key. save this! | string | `""` | no |

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ Please contact your Technical Account Manager for more information, and support 
 | ssl\_policy | SSL policy for the cert | string | n/a | yes |
 | subnet | name of the subnet to install into | string | n/a | yes |
 | airgap\_installer\_url | URL to replicated's airgap installer package | string | `"https://install.terraform.io/installer/replicated-v5.tar.gz"` | no |
-| ca_bundle_url | URL to CA certificate file used for the internal `ptfe-proxy` used for outgoing connections| string | `"none"` | no |
 | airgap\_package\_url | airgap url | string | `"none"` | no |
 | boot\_disk\_size | The size of the boot disk to use for the instances | string | `"40"` | no |
+| ca_bundle_url | URL to Custom CA bundle used for outgoing connections | string | `"none"` | no |
 | encryption\_password | encryption password for the vault unseal key. save this! | string | `""` | no |
 | external\_services | object store provider for external services. Allowed values: gcs | string | `""` | no |
 | gcs\_bucket | Name of the gcp storage bucket | string | `""` | no |

--- a/files/install-ptfe.sh
+++ b/files/install-ptfe.sh
@@ -206,18 +206,23 @@ if [[ $(< /etc/ptfe/airgap-installer-url) != none ]]; then
     airgap_installer_url_path="/etc/ptfe/airgap-installer-url"
 fi
 
+# ------------------------------------------------------------------------------
+# Custom CA certificate download and configuration block
+# ------------------------------------------------------------------------------
 if [[ -n $(< /etc/ptfe/custom-ca-cert-url) && \
       $(< /etc/ptfe/custom-ca-cert-url) != none ]]; then
   custom_ca_bundle_url=$(cat /etc/ptfe/custom-ca-cert-url)
   custom_ca_cert_file_name=$(echo "${custom_ca_bundle_url}" | awk -F '/' '{ print $NF }')
-  ca_tmp_dir="/tmp/ptfe/customer-certs"
+  ca_tmp_dir="/tmp/ptfe-customer-certs"
   replicated_conf_file="replicated-ptfe.conf"
   local_messages_file="local_messages.log"
-  # Setting up a tmp directory to do this `jq` transform to leave artifacts if anything goes "boom".
+  # Setting up a tmp directory to do this `jq` transform to leave artifacts if anything goes "boom",
+  # since we're trusting user input to be both a working URL and a valid certificate.
+  # These artifacts will live in /tmp/ptfe/customer-certs/{local_messages.log,wget_output.log} files.
   mkdir -p "${ca_tmp_dir}"
   pushd "${ca_tmp_dir}"
   touch ${local_messages_file}
-  if wget --trust-server-files "${custom_ca_bundle_url}" >> ./wget_output.log 2>&1;
+  if wget --trust-server-names "${custom_ca_bundle_url}" >> ./wget_output.log 2>&1;
   then
     if [ -f "${ca_tmp_dir}/${custom_ca_cert_file_name}" ];
     then

--- a/files/install-ptfe.sh
+++ b/files/install-ptfe.sh
@@ -208,8 +208,8 @@ fi
 
 if [[ -n $(< /etc/ptfe/custom-ca-cert-url) && \
       $(< /etc/ptfe/custom-ca-cert-url) != none ]]; then
-  custom_ca_cert_url=$(cat /etc/ptfe/custom-ca-cert-url)
-  custom_ca_cert_file_name=$(echo "${custom_ca_cert_url}" | awk -F '/' '{ print $NF }')
+  custom_ca_bundle_url=$(cat /etc/ptfe/custom-ca-cert-url)
+  custom_ca_cert_file_name=$(echo "${custom_ca_bundle_url}" | awk -F '/' '{ print $NF }')
   ca_tmp_dir="/tmp/ptfe/customer-certs"
   replicated_conf_file="replicated-ptfe.conf"
   local_messages_file="local_messages.log"
@@ -217,7 +217,7 @@ if [[ -n $(< /etc/ptfe/custom-ca-cert-url) && \
   mkdir -p "${ca_tmp_dir}"
   pushd "${ca_tmp_dir}"
   touch ${local_messages_file}
-  if wget --trust-server-files "${custom_ca_cert_url}" >> ./wget_output.log 2>&1;
+  if wget --trust-server-files "${custom_ca_bundle_url}" >> ./wget_output.log 2>&1;
   then
     if [ -f "${ca_tmp_dir}/${custom_ca_cert_file_name}" ];
     then
@@ -239,12 +239,12 @@ if [[ -n $(< /etc/ptfe/custom-ca-cert-url) && \
         echo "" | tee -a "${local_messages_file}"
       fi
     else
-      echo "The filename ${custom_ca_cert_file_name} was not what ${custom_ca_cert_url} downloaded." | tee -a "${local_messages_file}"
+      echo "The filename ${custom_ca_cert_file_name} was not what ${custom_ca_bundle_url} downloaded." | tee -a "${local_messages_file}"
       echo "Inspect the ${ca_tmp_dir} directory to verify the file that was downloaded." | tee -a "${local_messages_file}"
       echo "" | tee -a "${local_messages_file}"
     fi
   else
-    echo "There was an error downloading the file ${custom_ca_cert_file_name} from ${custom_ca_cert_url}." | tee -a "${local_messages_file}"
+    echo "There was an error downloading the file ${custom_ca_cert_file_name} from ${custom_ca_bundle_url}." | tee -a "${local_messages_file}"
     echo "See the ${ca_tmp_dir}/wget_output.log file." | tee -a "${local_messages_file}"
     echo "" | tee -a "${local_messages_file}"
   fi

--- a/modules/instance-template/README.md
+++ b/modules/instance-template/README.md
@@ -16,7 +16,7 @@
 | secondary\_machine\_type | Type of machine to use | string | n/a | yes |
 | setup\_token | setup token | string | n/a | yes |
 | boot\_disk\_size | The size of the boot disk to use for the instances | string | `"40"` | no |
-| ca_cert_url | URL to CA certificate file used for the internal `ptfe-proxy` used for outgoing connections| string | `"none"` | no |
+| ca_bundle_url | URL to CA certificate file used for the internal `ptfe-proxy` used for outgoing connections| string | `"none"` | no |
 
 ## Outputs
 

--- a/modules/instance-template/secondary.tf
+++ b/modules/instance-template/secondary.tf
@@ -28,7 +28,7 @@ resource "google_compute_instance_template" "secondary" {
     //enable-oslogin       = "TRUE"
     bootstrap-token      = "${var.bootstrap_token_id}.${var.bootstrap_token_suffix}"
     setup-token          = "${var.setup_token}"
-    custom-ca-cert-url   = "${var.ca_cert_url}"
+    custom-ca-cert-url   = "${var.ca_bundle_url}"
     cluster-api-endpoint = "${var.cluster_endpoint}:6443"
     primary-pki-url      = "http://${var.cluster_endpoint}:${local.assistant_port}/api/v1/pki-download?token=${var.setup_token}"
     health-url           = "http://${var.cluster_endpoint}:${local.assistant_port}/healthz"

--- a/modules/instance-template/variables.tf
+++ b/modules/instance-template/variables.tf
@@ -68,7 +68,7 @@ variable "prefix" {
   description = "Prefix for resource names"
 }
 
-variable "ca_cert_url" {
+variable "ca_bundle_url" {
   type        = "string"
   description = "URL to CA certificate file used for the internal `ptfe-proxy` used for outgoing connections"
   default     = "none"

--- a/primary.tf
+++ b/primary.tf
@@ -1,6 +1,6 @@
 resource "google_compute_instance" "primary" {
   # The number of primaries must be hard coded to 3 when Internal Production Mode
-  # is selected. Currently, that mode does not support scaling. In other modes, the 
+  # is selected. Currently, that mode does not support scaling. In other modes, the
   count = "${var.install_type == "ipm" ? 3 : var.primary_count}"
 
   name         = "${var.prefix}-primary-${count.index}"
@@ -30,7 +30,7 @@ resource "google_compute_instance" "primary" {
     cluster-api-endpoint = "${var.prefix}-primary-0:6443"
     primary-pki-url      = "http://${var.prefix}-primary-0:${local.assistant_port}/api/v1/pki-download?token=${random_string.setup_token.result}"
     health-url           = "http://${var.prefix}-primary-0:${local.assistant_port}/healthz"
-    custom-ca-cert-url   = "${var.ca_cert_url}"
+    custom-ca-cert-url   = "${var.ca_bundle_url}"
     ptfe-role            = "${count.index == 0 ? "main" : "primary"}"
     role-id              = "${count.index}"
     b64-license          = "${base64encode(file("${var.license_file}"))}"

--- a/variables.tf
+++ b/variables.tf
@@ -153,9 +153,9 @@ variable "boot_disk_size" {
   default     = 40
 }
 
-variable "ca_cert_url" {
+variable "ca_bundle_url" {
   type        = "string"
-  description = "URL to CA certificate file used for the internal `ptfe-proxy` used for outgoing connections"
+  description = "URL to Custom CA bundle used for outgoing connections"
   default     = "none"
 }
 


### PR DESCRIPTION
Related to https://github.com/hashicorp/terraform-aws-terraform-enterprise/pull/17

Quoting that issue: 

> This PR fixes an issue where the ca_cert_url would error out while trying to retrieve it.
> 
> There were two problems:
> 
> 1. It attempted to use `/tmp/ptfe/customer-certs` as a working dir, but the downloaded `ptfe` tool was still in the `/tmp` dir causing it to collide and error out.
> 2. `wget` was passed an arg it did not recognize.
> 
> Couple quick fixes and it works! 🎉
> 
> Part 2 of this PR is something that's easy to revert and I'm open to it this late in the game but I changed the variable to `ca_bundle_url`. I did this to better match the terminology we use in the settings UI and to denote that this can be a whole bundle and not just a single cert.
> 
> These fixes may need to be applied to Azure and GCP once this is merged (and if we do go with the rename we'll need to make those match for ease of use).


