### PR TITLE
Airgap fix and add ubuntu 18.04 back as default

### DIFF
--- a/files/install-ptfe.sh
+++ b/files/install-ptfe.sh
@@ -295,6 +295,12 @@ ptfe_install_args=(
     "--private-address=$(curl -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ip)"
 )
 
+if [[ $(</etc/ptfe/airgap-package-url) != "none" ]]; then
+  ptfe_install_args+=(
+    --airgap
+  )
+fi
+
 if [ "x${role}x" == "xmainx" ]; then
     verb="setup"
     export verb

--- a/files/install-ptfe.sh
+++ b/files/install-ptfe.sh
@@ -2,9 +2,6 @@
 
 set -e -u -o pipefail
 
-# Install pre-reqs
-apt-get update -y
-apt-get install -y jq chrony ipvsadm unzip wget
 # Grab all the install/config data from gcp's metadata store
 mkdir /etc/ptfe
 curl "http://metadata.google.internal/computeMetadata/v1/instance/attributes/ptfe-role" -H "Metadata-Flavor: Google" -o /etc/ptfe/role

--- a/files/install-ptfe.sh
+++ b/files/install-ptfe.sh
@@ -60,22 +60,24 @@ if [[ $(< /etc/ptfe/role) != "secondary" ]]; then
     export PTFEHOSTNAME
     ENCPASSWD=$(cat /etc/ptfe/encpasswd)
     export ENCPASSWD
-    PG_USER=$(cat /etc/ptfe/pg_user)
-    export PG_USER
-    PG_PASSWORD=$(base64 --decode /etc/ptfe/pg_password)
-    export PG_PASSWORD
-    PG_NETLOC=$(cat /etc/ptfe/pg_netloc)
-    export PG_NETLOC
-    PG_DBNAME=$(cat /etc/ptfe/pg_dbname)
-    export PG_DBNAME
-    PG_EXTRA_PARAMS=$(cat /etc/ptfe/pg_extra_params)
-    export PG_EXTRA_PARAMS
-    GCS_PROJECT=$(cat /etc/ptfe/gcs_project)
-    export GCS_PROJECT
-    GCS_BUCKET=$(cat /etc/ptfe/gcs_bucket)
-    export GCS_BUCKET
-    GCS_CREDS=$(base64 --decode /etc/ptfe/gcs_credentials | jq -c . | sed -e 's/"/\\"/g' -e 's/\\n/\\\\n/g')
-    export GCS_CREDS
+    if [[ $(< /etc/ptfe/installtype) == "production" ]]; then
+        PG_USER=$(cat /etc/ptfe/pg_user)
+        export PG_USER
+        PG_PASSWORD=$(base64 --decode /etc/ptfe/pg_password)
+        export PG_PASSWORD
+        PG_NETLOC=$(cat /etc/ptfe/pg_netloc)
+        export PG_NETLOC
+        PG_DBNAME=$(cat /etc/ptfe/pg_dbname)
+        export PG_DBNAME
+        PG_EXTRA_PARAMS=$(cat /etc/ptfe/pg_extra_params)
+        export PG_EXTRA_PARAMS
+        GCS_PROJECT=$(cat /etc/ptfe/gcs_project)
+        export GCS_PROJECT
+        GCS_BUCKET=$(cat /etc/ptfe/gcs_bucket)
+        export GCS_BUCKET
+        GCS_CREDS=$(base64 --decode /etc/ptfe/gcs_credentials | jq -c . | sed -e 's/"/\\"/g' -e 's/\\n/\\\\n/g')
+        export GCS_CREDS
+    fi
 fi
 
 # Setup the config files that will be used during the install

--- a/files/install-ptfe.sh
+++ b/files/install-ptfe.sh
@@ -141,7 +141,8 @@ chown root:root /etc/replicated-ptfe.conf
 chmod 0644 /etc/replicated-ptfe.conf
 
 if [[ $(< /etc/ptfe/release-sequence) != latest ]]; then
-    /bin/cat <<EOF >/etc/replicated.conf
+    if [[ $(< /etc/ptfe/airgap-package-url) != none ]]; then
+        /bin/cat <<EOF >/etc/replicated.conf
 {
     "DaemonAuthenticationType":     "password",
     "DaemonAuthenticationPassword": "$CONSOLE",
@@ -152,7 +153,34 @@ if [[ $(< /etc/ptfe/release-sequence) != latest ]]; then
     "ReleaseSequence":              $RELEASE_SEQUENCE
 }
 EOF
+    else
+        /bin/cat <<EOF >/etc/replicated.conf
+{
+    "DaemonAuthenticationType":     "password",
+    "DaemonAuthenticationPassword": "$CONSOLE",
+    "TlsBootstrapType":             "self-signed",
+    "BypassPreflightChecks":        true,
+    "ImportSettingsFrom":           "/etc/replicated-ptfe.conf",
+    "LicenseFileLocation":          "/etc/replicated.rli",
+    "LicenseBootstrapAirgapPackagePath":    "/var/lib/ptfe/ptfe.airgap",
+    "ReleaseSequence":              $RELEASE_SEQUENCE
+}
+EOF
+    fi
 
+else
+    if [[ $(< /etc/ptfe/airgap-package-url) != none ]]; then
+        /bin/cat <<EOF >/etc/replicated.conf
+{
+    "DaemonAuthenticationType":     "password",
+    "DaemonAuthenticationPassword": "$CONSOLE",
+    "TlsBootstrapType":             "self-signed",
+    "BypassPreflightChecks":        true,
+    "ImportSettingsFrom":           "/etc/replicated-ptfe.conf",
+    "LicenseBootstrapAirgapPackagePath":    "/var/lib/ptfe/ptfe.airgap",
+    "LicenseFileLocation":          "/etc/replicated.rli"
+}
+EOF
 else
 /bin/cat <<EOF >/etc/replicated.conf
 {
@@ -164,6 +192,7 @@ else
     "LicenseFileLocation":          "/etc/replicated.rli"
 }
 EOF
+fi
 fi
 
 chown root:root /etc/replicated.conf

--- a/variables.tf
+++ b/variables.tf
@@ -162,7 +162,7 @@ variable "ca_bundle_url" {
 variable "image_family" {
   type        = "string"
   description = "The image family, choose from ubuntu-1604-lts, ubuntu-1804-lts, or rhel-7"
-  default     = "ubuntu-1604-lts"
+  default     = "ubuntu-1804-lts"
 }
 
 variable "primary_count" {


### PR DESCRIPTION
Piping through the `--airgap` flag in the install script to properly setup airgap cluster.

Also added back in ubuntu 18.04 due to fix in ptfe tool.