### PR TITLE
Only run the Custom CA Bundle setup function on the main server

### DIFF
--- a/files/install-ptfe.sh
+++ b/files/install-ptfe.sh
@@ -68,7 +68,7 @@ else
   SERVICE=chrony
 fi
 
-# Store various bits of info as env vars 
+# Store various bits of info as env vars
 base64 -d /etc/ptfe/replicated-licenseb64 > /etc/replicated.rli
 PTFEHOSTNAME=$(cat /etc/ptfe/hostname)
 PTFEHOSTNAME=${PTFEHOSTNAME%?}
@@ -236,56 +236,7 @@ if [[ $(< /etc/ptfe/airgap-installer-url) != none ]]; then
     airgap_installer_url_path="/etc/ptfe/airgap-installer-url"
 fi
 
-# ------------------------------------------------------------------------------
-# Custom CA certificate download and configuration block
-# ------------------------------------------------------------------------------
-if [[ -n $(< /etc/ptfe/custom-ca-cert-url) && \
-      $(< /etc/ptfe/custom-ca-cert-url) != none ]]; then
-  custom_ca_bundle_url=$(cat /etc/ptfe/custom-ca-cert-url)
-  custom_ca_cert_file_name=$(echo "${custom_ca_bundle_url}" | awk -F '/' '{ print $NF }')
-  ca_tmp_dir="/tmp/ptfe-customer-certs"
-  replicated_conf_file="replicated-ptfe.conf"
-  local_messages_file="local_messages.log"
-  # Setting up a tmp directory to do this `jq` transform to leave artifacts if anything goes "boom",
-  # since we're trusting user input to be both a working URL and a valid certificate.
-  # These artifacts will live in /tmp/ptfe/customer-certs/{local_messages.log,wget_output.log} files.
-  mkdir -p "${ca_tmp_dir}"
-  pushd "${ca_tmp_dir}"
-  touch ${local_messages_file}
-  if wget --trust-server-names "${custom_ca_bundle_url}" >> ./wget_output.log 2>&1;
-  then
-    if [ -f "${ca_tmp_dir}/${custom_ca_cert_file_name}" ];
-    then
-      if openssl x509 -in "${custom_ca_cert_file_name}" -text -noout;
-      then
-        mv "${custom_ca_cert_file_name}" cust-ca-certificates.crt
-        cp /etc/${replicated_conf_file} ./${replicated_conf_file}.original
-        jq ". + { ca_certs: { value: \"$(cat cust-ca-certificates.crt)\" } }" -- ${replicated_conf_file}.original > ${replicated_conf_file}.updated
-        if jq -e . > /dev/null 2>&1 -- ${replicated_conf_file}.updated;
-        then
-          cp ./${replicated_conf_file}.updated /etc/${replicated_conf_file}
-        else
-          echo "The updated ${replicated_conf_file} file is not valid JSON." | tee -a "${local_messages_file}"
-          echo "Review ${ca_tmp_dir}/${replicated_conf_file}.original and ${ca_tmp_dir}/${replicated_conf_file}.updated." | tee -a "${local_messages_file}"
-          echo "" | tee -a "${local_messages_file}"
-        fi
-      else
-        echo "The certificate file wasn't able to validated via openssl" | tee -a "${local_messages_file}"
-        echo "" | tee -a "${local_messages_file}"
-      fi
-    else
-      echo "The filename ${custom_ca_cert_file_name} was not what ${custom_ca_bundle_url} downloaded." | tee -a "${local_messages_file}"
-      echo "Inspect the ${ca_tmp_dir} directory to verify the file that was downloaded." | tee -a "${local_messages_file}"
-      echo "" | tee -a "${local_messages_file}"
-    fi
-  else
-    echo "There was an error downloading the file ${custom_ca_cert_file_name} from ${custom_ca_bundle_url}." | tee -a "${local_messages_file}"
-    echo "See the ${ca_tmp_dir}/wget_output.log file." | tee -a "${local_messages_file}"
-    echo "" | tee -a "${local_messages_file}"
-  fi
 
-  popd
-fi
 
 ptfe_install_args=(
     -DD
@@ -339,6 +290,57 @@ if [ "x${role}x" == "xmainx" ]; then
         ptfe_install_args+=(
             "--service-cidr=$(cat /etc/ptfe/repl-cidr)"
         )
+    fi
+
+    # ------------------------------------------------------------------------------
+    # Custom CA certificate download and configuration block
+    # ------------------------------------------------------------------------------
+    if [[ -n $(< /etc/ptfe/custom-ca-cert-url) && \
+        $(< /etc/ptfe/custom-ca-cert-url) != none ]]; then
+    custom_ca_bundle_url=$(cat /etc/ptfe/custom-ca-cert-url)
+    custom_ca_cert_file_name=$(echo "${custom_ca_bundle_url}" | awk -F '/' '{ print $NF }')
+    ca_tmp_dir="/tmp/ptfe-customer-certs"
+    replicated_conf_file="replicated-ptfe.conf"
+    local_messages_file="local_messages.log"
+    # Setting up a tmp directory to do this `jq` transform to leave artifacts if anything goes "boom",
+    # since we're trusting user input to be both a working URL and a valid certificate.
+    # These artifacts will live in /tmp/ptfe/customer-certs/{local_messages.log,wget_output.log} files.
+    mkdir -p "${ca_tmp_dir}"
+    pushd "${ca_tmp_dir}"
+    touch ${local_messages_file}
+    if wget --trust-server-names "${custom_ca_bundle_url}" >> ./wget_output.log 2>&1;
+    then
+        if [ -f "${ca_tmp_dir}/${custom_ca_cert_file_name}" ];
+        then
+        if openssl x509 -in "${custom_ca_cert_file_name}" -text -noout;
+        then
+            mv "${custom_ca_cert_file_name}" cust-ca-certificates.crt
+            cp /etc/${replicated_conf_file} ./${replicated_conf_file}.original
+            jq ". + { ca_certs: { value: \"$(cat cust-ca-certificates.crt)\" } }" -- ${replicated_conf_file}.original > ${replicated_conf_file}.updated
+            if jq -e . > /dev/null 2>&1 -- ${replicated_conf_file}.updated;
+            then
+            cp ./${replicated_conf_file}.updated /etc/${replicated_conf_file}
+            else
+            echo "The updated ${replicated_conf_file} file is not valid JSON." | tee -a "${local_messages_file}"
+            echo "Review ${ca_tmp_dir}/${replicated_conf_file}.original and ${ca_tmp_dir}/${replicated_conf_file}.updated." | tee -a "${local_messages_file}"
+            echo "" | tee -a "${local_messages_file}"
+            fi
+        else
+            echo "The certificate file wasn't able to validated via openssl" | tee -a "${local_messages_file}"
+            echo "" | tee -a "${local_messages_file}"
+        fi
+        else
+        echo "The filename ${custom_ca_cert_file_name} was not what ${custom_ca_bundle_url} downloaded." | tee -a "${local_messages_file}"
+        echo "Inspect the ${ca_tmp_dir} directory to verify the file that was downloaded." | tee -a "${local_messages_file}"
+        echo "" | tee -a "${local_messages_file}"
+        fi
+    else
+        echo "There was an error downloading the file ${custom_ca_cert_file_name} from ${custom_ca_bundle_url}." | tee -a "${local_messages_file}"
+        echo "See the ${ca_tmp_dir}/wget_output.log file." | tee -a "${local_messages_file}"
+        echo "" | tee -a "${local_messages_file}"
+    fi
+
+    popd
     fi
 fi
 


### PR DESCRIPTION
Related to https://github.com/hashicorp/terraform-aws-terraform-enterprise/pull/22

>Came up in testing where other nodes could not join the cluster as they were attempting to setup a custom ca bundle which mutates the replicated-ptfe.conf but that file is only placed on the first server (which we refer to as "main" in the scripts).
>
>This PR moves the setup of the bundle into the area of setup that only runs on main which fixes the issue.