### PR TITLE
Add the prefix to the name of the secondary instance group

### DIFF
--- a/secondary.tf
+++ b/secondary.tf
@@ -12,7 +12,7 @@ resource "google_compute_health_check" "autohealing" {
 }
 
 resource "google_compute_region_instance_group_manager" "secondary" {
-  name = "secondary"
+  name = "${var.prefix}-secondary"
 
   base_instance_name = "${var.prefix}-secondary"
   instance_template  = "${module.instance-template.secondary_template}"

--- a/secondary.tf
+++ b/secondary.tf
@@ -29,9 +29,9 @@ resource "google_compute_region_autoscaler" "secondary" {
   target = "${google_compute_region_instance_group_manager.secondary.self_link}"
 
   autoscaling_policy {
-    max_replicas      = "${var.max_secondaries}"
-    min_replicas      = "${var.min_secondaries}"
-    cooldown_period   = 300
+    max_replicas    = "${var.max_secondaries}"
+    min_replicas    = "${var.min_secondaries}"
+    cooldown_period = 300
 
     cpu_utilization {
       target = "${var.autoscaler_cpu}"

--- a/secondary.tf
+++ b/secondary.tf
@@ -1,5 +1,5 @@
 resource "google_compute_health_check" "autohealing" {
-  name                = "autohealing-health-check"
+  name                = "${var.prefix}-autohealing-health-check"
   check_interval_sec  = 5
   timeout_sec         = 5
   healthy_threshold   = 2

--- a/secondary.tf
+++ b/secondary.tf
@@ -34,7 +34,7 @@ resource "google_compute_region_autoscaler" "secondary" {
     cooldown_period = 300
 
     cpu_utilization {
-      target = "${var.autoscaler_cpu}"
+      target = "${var.autoscaler_cpu_threshold}"
     }
   }
 }

--- a/secondary.tf
+++ b/secondary.tf
@@ -18,10 +18,23 @@ resource "google_compute_region_instance_group_manager" "secondary" {
   instance_template  = "${module.instance-template.secondary_template}"
   region             = "${var.region}"
 
-  target_size = "${var.secondary_count}"
-
   named_port {
     name = "https"
     port = 443
+  }
+}
+
+resource "google_compute_region_autoscaler" "secondary" {
+  name   = "secondary-autoscaler"
+  target = "${google_compute_region_instance_group_manager.secondary.self_link}"
+
+  autoscaling_policy {
+    max_replicas      = "${var.max_secondaries}"
+    min_replicas      = "${var.min_secondaries}"
+    cooldown_period   = 300
+
+    cpu_utilization {
+      target = "${var.autoscaler_cpu}"
+    }
   }
 }

--- a/secondary.tf
+++ b/secondary.tf
@@ -3,7 +3,7 @@ resource "google_compute_health_check" "autohealing" {
   check_interval_sec  = 5
   timeout_sec         = 5
   healthy_threshold   = 2
-  unhealthy_threshold = 10                         # 50 seconds
+  unhealthy_threshold = 10                                       # 50 seconds
 
   http_health_check {
     request_path = "/_health_check"

--- a/variables.tf
+++ b/variables.tf
@@ -81,10 +81,22 @@ variable "primary_count" {
   default     = "3"
 }
 
-variable "secondary_count" {
+variable "max_secondaries" {
   type        = "string"
-  description = "Number of secondary nodes to run"
+  description = "The maximum number of secondaries in the autoscaling group"
+  default     = "3"
+}
+
+variable "min_secondaries" {
+  type        = "string"
+  description = "The minimum number of secondaries in the autoscaling group"
   default     = "0"
+}
+
+variable "autoscaler_cpu" {
+  type        = "string"
+  description = "The cpu threshold at which the autoscaling group to build another instance"
+  default     = "0.7"
 }
 
 variable "region" {

--- a/variables.tf
+++ b/variables.tf
@@ -93,7 +93,7 @@ variable "min_secondaries" {
   default     = "0"
 }
 
-variable "autoscaler_cpu" {
+variable "autoscaler_cpu_threshold" {
   type        = "string"
   description = "The cpu threshold at which the autoscaling group to build another instance"
   default     = "0.7"


### PR DESCRIPTION
This PR modifies the secondaries to be part of an autoscaling group. This removes the 'secondary_count' variable, and adds 'min_secondaries' and 'max_secondaries', with default values of 1 and 3, respectively. README and examples have been updated to reflect this. 