### PR TITLE
Uniquely name internal proxy health check and ssl policy

### DIFF
--- a/modules/cluster/modules/internal_lb/proxy.tf
+++ b/modules/cluster/modules/internal_lb/proxy.tf
@@ -1,5 +1,5 @@
 resource "google_compute_health_check" "autohealing" {
-  name                = "${var.prefix}haproxy-health-check"
+  name                = "${var.prefix}haproxy-health-check-${var.install_id}"
   check_interval_sec  = 5
   timeout_sec         = 5
   healthy_threshold   = 2
@@ -53,4 +53,3 @@ resource "google_compute_region_instance_group_manager" "haproxy" {
     port = 6443
   }
 }
-

--- a/modules/lb/main.tf
+++ b/modules/lb/main.tf
@@ -32,6 +32,7 @@ resource "google_compute_url_map" "tfe" {
 }
 
 resource "google_compute_ssl_policy" "default_policy" {
+  count           = var.ssl_policy == "" ? 1 : 0
   name            = "${var.prefix}tfe-${var.install_id}"
   profile         = "RESTRICTED"
   min_tls_version = "TLS_1_2"
@@ -41,7 +42,7 @@ resource "google_compute_target_https_proxy" "tfe" {
   name             = "${var.prefix}https-${var.install_id}"
   url_map          = google_compute_url_map.tfe.self_link
   ssl_certificates = [var.cert]
-  ssl_policy       = var.ssl_policy != "" ? var.ssl_policy : google_compute_ssl_policy.default_policy.self_link
+  ssl_policy       = var.ssl_policy != "" ? var.ssl_policy : google_compute_ssl_policy.default_policy[0].self_link
 }
 
 resource "google_compute_global_address" "application" {

--- a/modules/lb/main.tf
+++ b/modules/lb/main.tf
@@ -32,7 +32,7 @@ resource "google_compute_url_map" "tfe" {
 }
 
 resource "google_compute_ssl_policy" "default_policy" {
-  name            = "ptfe-ssl-policy"
+  name            = "${var.prefix}tfe-${var.install_id}"
   profile         = "RESTRICTED"
   min_tls_version = "TLS_1_2"
 }
@@ -56,4 +56,3 @@ resource "google_compute_global_forwarding_rule" "https" {
 
   load_balancing_scheme = "EXTERNAL"
 }
-


### PR DESCRIPTION
## Background

These are the two resources I found trying to create a second installation in a single project. The ternary in count for the policy creation I noticed while fixing the names. I'm not sure if you want to start adding those at the moment.

## How Has This Been Tested

I was able to install a second installation in a single project with no further errors.

### Test Configuration

* Terraform Version: 12.17
* Any additional relevant variables:
