### PR TITLE
Expose cluster secondary scaling variables to top level module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -100,6 +100,10 @@ module "cluster" {
   postgresql_database = module.postgres.database_name
   postgresql_user     = module.postgres.user
   postgresql_password = module.postgres.password
+
+  max_secondaries          = var.max_secondaries
+  min_secondaries          = var.min_secondaries
+  autoscaler_cpu_threshold = var.autoscaler_cpu_threshold
 }
 
 # Configures DNS entries for the primaries as a convenience
@@ -143,4 +147,3 @@ module "dns" {
   dnszone  = var.dnszone
   hostname = var.hostname
 }
-

--- a/variables.tf
+++ b/variables.tf
@@ -41,3 +41,25 @@ variable "prefix" {
   description = "Prefix to apply to all resources names"
   default     = "tfe-"
 }
+
+###################################################
+# Cluster secondary scaling
+###################################################
+
+variable "max_secondaries" {
+  type        = string
+  description = "The maximum number of secondaries in the autoscaling group"
+  default     = "3"
+}
+
+variable "min_secondaries" {
+  type        = string
+  description = "The minimum number of secondaries in the autoscaling group"
+  default     = "0"
+}
+
+variable "autoscaler_cpu_threshold" {
+  type        = string
+  description = "The cpu threshold at which the autoscaling group to build another instance"
+  default     = "0.7"
+}


### PR DESCRIPTION
## Background

Currently `min_secondaries` defaults to `0` but it's not exposed for use by the top level module.

## How Has This Been Tested

I modified a running cluster with an increased secondary count and they were created and successfully joined the cluster.

### Test Configuration

* Terraform Version: 12.17
* Any additional relevant variables:
