### PR TITLE
Additional postgresql options

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -37,6 +37,9 @@ module "postgres" {
   prefix     = var.prefix
 
   network_url = module.vpc.network_url
+
+  postgresql_availability_type = var.postgresql_availability_type
+  postgresql_backup_start_time = var.postgresql_backup_start_time
 }
 
 # Create a GCP service account to access our GCS bucket

--- a/modules/postgres/main.tf
+++ b/modules/postgres/main.tf
@@ -28,11 +28,17 @@ resource "google_sql_database_instance" "tfe" {
   settings {
     # Second-generation instance tiers are based on the machine
     # type. See argument reference below.
-    tier = var.postgresql_machinetype
+    tier              = var.postgresql_machinetype
+    availability_type = var.postgresql_availability_type
 
     ip_configuration {
       ipv4_enabled    = false
       private_network = var.network_url
+    }
+
+    backup_configuration {
+      enabled    = var.postgresql_backup_start_time == "" ? false : true
+      start_time = var.postgresql_backup_start_time
     }
 
     user_labels = var.labels
@@ -59,4 +65,3 @@ resource "google_sql_user" "tfe" {
 
   password = local.password
 }
-

--- a/modules/postgres/variables.tf
+++ b/modules/postgres/variables.tf
@@ -43,3 +43,15 @@ variable "postgresql_password" {
   description = "Password for Postgres Database"
   default     = ""
 }
+
+variable "postgresql_availability_type" {
+  type        = string
+  description = "This specifies whether a PostgreSQL instance should be set up for high availability (REGIONAL) or single zone (ZONAL)"
+  default     = "ZONAL"
+}
+
+variable "postgresql_backup_start_time" {
+  type        = string
+  description = "HH:MM format time indicating when backup configuration starts."
+  default     = ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -41,3 +41,19 @@ variable "prefix" {
   description = "Prefix to apply to all resources names"
   default     = "tfe-"
 }
+
+###################################################
+# Postgresql options
+###################################################
+
+variable "postgresql_availability_type" {
+  type        = string
+  description = "This specifies whether a PostgreSQL instance should be set up for high availability (REGIONAL) or single zone (ZONAL)"
+  default     = "ZONAL"
+}
+
+variable "postgresql_backup_start_time" {
+  type        = string
+  description = "HH:MM format time indicating when backup configuration starts."
+  default     = ""
+}


### PR DESCRIPTION
Enable selecting `REGIONAL` availability type
Enable automated backup configuration

## Background

Expose higher availability options for the postgresql module

## How Has This Been Tested

I modified a running cluster and the settings were added correctly. I have not yet tried to downgrade the instance or disable backups.

### Test Configuration

* Terraform Version: 12.7
* Any additional relevant variables:
