### PR TITLE
Root example re-roll

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,22 @@ Please contact your Technical Account Manager for more information, and support 
 The following sections describe aspects of using this
 module.
 
+### Permissions
+
+The following roles must be assigned to the GCP identity
+used to provision this module:
+
+- Cloud SQL Admin: `roles/cloudsql.admin`
+- Compute Admin: `roles/compute.admin`
+- Service Account Admin:
+  `roles/iam.serviceAccountAdmin`
+- DNS Administrator: `roles/dns.admin`
+- Service Networking Admin:
+  `roles/servicenetworking.networksAdmin`
+- Service Account Key Admin:
+  `roles/iam.serviceAccountKeyAdmin`
+- Storage Admin: `roles/storage.admin`
+
 ### Examples
 
 Please see the [examples directory](https://github.com/hashicorp/terraform-google-terraform-enterprise/tree/master/examples/) for more extensive examples.

--- a/README.md
+++ b/README.md
@@ -15,17 +15,22 @@ _example architecture_
 
 Please contact your Technical Account Manager for more information, and support for any issues you have.
 
-## Examples
+## Usage
+
+The following sections describe aspects of using this
+module.
+
+### Examples
 
 Please see the [examples directory](https://github.com/hashicorp/terraform-google-terraform-enterprise/tree/master/examples/) for more extensive examples.
 
-## Inputs
+### Inputs
 
 Please see the [inputs documentation](https://registry.terraform.io/modules/hashicorp/terraform-enterprise/google/?tab=inputs)
 
 Repository versions of the inputs documentation can be found in [docs/inputs.md](docs/inputs.md)
 
-## Outputs
+### Outputs
 
 Please see the [outputs documentation](https://registry.terraform.io/modules/hashicorp/terraform-enterprise/google/?tab=outputs)
 

--- a/examples/root-example/main.tf
+++ b/examples/root-example/main.tf
@@ -28,14 +28,3 @@ module "tfe-cluster" {
 
   license_file = "customer.rli"
 }
-
-output "tfe-cluster" {
-  value = {
-    application_endpoint         = "${module.tfe-cluster.application_endpoint}"
-    application_health_check     = "${module.tfe-cluster.application_health_check}"
-    installer_dashboard_password = "${module.tfe-cluster.installer_dashboard_password}"
-    installer_dashboard__url     = "${module.tfe-cluster.installer_dashboard_url}"
-    primary_public_ip            = "${module.tfe-cluster.primary_public_ip}"
-    encryption_password          = "${module.tfe-beta.encryption_password}"
-  }
-}

--- a/examples/root-example/main.tf
+++ b/examples/root-example/main.tf
@@ -23,21 +23,10 @@ provider "template" {
 module "tfe-cluster" {
   source = "../.."
 
-  credentials_file = "auth-file-123456678.json"
-  region           = var.region
-  zone             = "${var.region}-a"
-  project          = var.project
-  domain           = "example.com"
-  dns_zone         = "example"
-  public_ip        = "1.2.3.4"
-  certificate      = "https://www.googleapis.com/compute/v1/project/terraform-test/global/sslCertificates/tfe"
-  ssl_policy       = "tfe-ssl-policy"
-  subnet           = "tfe-subnet"
-  frontend_dns     = "tfe-cluster"
-
-  primary_count   = "3"
-  secondary_count = "2"
-
+  credentials  = "auth-file-123456678.json"
+  dnszone      = "example"
   license_file = "customer.rli"
-}
+  project      = var.project
 
+  region = var.region
+}

--- a/examples/root-example/main.tf
+++ b/examples/root-example/main.tf
@@ -1,9 +1,3 @@
-variable "region" {
-  default = "us-central1"
-}
-
-variable "project" {}
-
 provider "google" {
   region  = "${var.region}"
   project = "${var.project}"

--- a/examples/root-example/main.tf
+++ b/examples/root-example/main.tf
@@ -12,6 +12,14 @@ provider "google-beta" {
   project = "${var.project}"
 }
 
+provider "random" {
+  version = "~> 2.2"
+}
+
+provider "template" {
+  version = "~> 2.1"
+}
+
 module "tfe-cluster" {
   source = "../.."
 

--- a/examples/root-example/main.tf
+++ b/examples/root-example/main.tf
@@ -1,15 +1,15 @@
 provider "google" {
   version = "~> 3.0"
 
-  region  = "${var.region}"
-  project = "${var.project}"
+  region  = var.region
+  project = var.project
 }
 
 provider "google-beta" {
   version = "~> 3.0"
 
-  region  = "${var.region}"
-  project = "${var.project}"
+  region  = var.region
+  project = var.project
 }
 
 provider "random" {
@@ -24,9 +24,9 @@ module "tfe-cluster" {
   source = "../.."
 
   credentials_file = "auth-file-123456678.json"
-  region           = "${var.region}"
+  region           = var.region
   zone             = "${var.region}-a"
-  project          = "${var.project}"
+  project          = var.project
   domain           = "example.com"
   dns_zone         = "example"
   public_ip        = "1.2.3.4"
@@ -40,3 +40,4 @@ module "tfe-cluster" {
 
   license_file = "customer.rli"
 }
+

--- a/examples/root-example/main.tf
+++ b/examples/root-example/main.tf
@@ -1,9 +1,13 @@
 provider "google" {
+  version = "~> 3.0"
+
   region  = "${var.region}"
   project = "${var.project}"
 }
 
 provider "google-beta" {
+  version = "~> 3.0"
+
   region  = "${var.region}"
   project = "${var.project}"
 }

--- a/examples/root-example/main.tf
+++ b/examples/root-example/main.tf
@@ -23,9 +23,9 @@ provider "template" {
 module "tfe-cluster" {
   source = "../.."
 
-  credentials  = "auth-file-123456678.json"
-  dnszone      = "example"
-  license_file = "customer.rli"
+  credentials  = var.credentials
+  dnszone      = var.dnszone
+  license_file = var.license_file
   project      = var.project
 
   region = var.region

--- a/examples/root-example/main.tf
+++ b/examples/root-example/main.tf
@@ -21,7 +21,8 @@ provider "template" {
 }
 
 module "tfe-cluster" {
-  source = "../.."
+  source  = "hashicorp/terraform-enterprise/google"
+  version = "0.1.0"
 
   credentials  = var.credentials
   dnszone      = var.dnszone

--- a/examples/root-example/main.tf
+++ b/examples/root-example/main.tf
@@ -13,8 +13,8 @@ provider "google-beta" {
 }
 
 module "tfe-cluster" {
-  source           = "hashicorp/terraform-enterprise/google"
-  version          = "0.1.0"
+  source = "../.."
+
   credentials_file = "auth-file-123456678.json"
   region           = "${var.region}"
   zone             = "${var.region}-a"

--- a/examples/root-example/outputs.tf
+++ b/examples/root-example/outputs.tf
@@ -1,13 +1,5 @@
 output "tfe-cluster" {
-  value = {
-    application_endpoint         = module.tfe-cluster.application_endpoint
-    application_health_check     = module.tfe-cluster.application_health_check
-    installer_dashboard_password = module.tfe-cluster.installer_dashboard_password
-    installer_dashboard_url      = module.tfe-cluster.installer_dashboard_url
-    primary_public_ip            = module.tfe-cluster.primary_public_ip
-    encryption_password          = module.tfe-beta.encryption_password
-  }
+  value = module.tfe-cluster
 
   description = "Cluster information."
 }
-

--- a/examples/root-example/outputs.tf
+++ b/examples/root-example/outputs.tf
@@ -3,7 +3,7 @@ output "tfe-cluster" {
     application_endpoint         = "${module.tfe-cluster.application_endpoint}"
     application_health_check     = "${module.tfe-cluster.application_health_check}"
     installer_dashboard_password = "${module.tfe-cluster.installer_dashboard_password}"
-    installer_dashboard__url     = "${module.tfe-cluster.installer_dashboard_url}"
+    installer_dashboard_url      = "${module.tfe-cluster.installer_dashboard_url}"
     primary_public_ip            = "${module.tfe-cluster.primary_public_ip}"
     encryption_password          = "${module.tfe-beta.encryption_password}"
   }

--- a/examples/root-example/outputs.tf
+++ b/examples/root-example/outputs.tf
@@ -1,12 +1,13 @@
 output "tfe-cluster" {
   value = {
-    application_endpoint         = "${module.tfe-cluster.application_endpoint}"
-    application_health_check     = "${module.tfe-cluster.application_health_check}"
-    installer_dashboard_password = "${module.tfe-cluster.installer_dashboard_password}"
-    installer_dashboard_url      = "${module.tfe-cluster.installer_dashboard_url}"
-    primary_public_ip            = "${module.tfe-cluster.primary_public_ip}"
-    encryption_password          = "${module.tfe-beta.encryption_password}"
+    application_endpoint         = module.tfe-cluster.application_endpoint
+    application_health_check     = module.tfe-cluster.application_health_check
+    installer_dashboard_password = module.tfe-cluster.installer_dashboard_password
+    installer_dashboard_url      = module.tfe-cluster.installer_dashboard_url
+    primary_public_ip            = module.tfe-cluster.primary_public_ip
+    encryption_password          = module.tfe-beta.encryption_password
   }
 
   description = "Cluster information."
 }
+

--- a/examples/root-example/outputs.tf
+++ b/examples/root-example/outputs.tf
@@ -1,0 +1,12 @@
+output "tfe-cluster" {
+  value = {
+    application_endpoint         = "${module.tfe-cluster.application_endpoint}"
+    application_health_check     = "${module.tfe-cluster.application_health_check}"
+    installer_dashboard_password = "${module.tfe-cluster.installer_dashboard_password}"
+    installer_dashboard__url     = "${module.tfe-cluster.installer_dashboard_url}"
+    primary_public_ip            = "${module.tfe-cluster.primary_public_ip}"
+    encryption_password          = "${module.tfe-beta.encryption_password}"
+  }
+
+  description = "Cluster information."
+}

--- a/examples/root-example/variables.tf
+++ b/examples/root-example/variables.tf
@@ -1,3 +1,19 @@
+
+variable "credentials" {
+  type        = string
+  description = "Path to GCP credentials .json file"
+}
+
+variable "dnszone" {
+  type        = string
+  description = "Name of the managed dns zone to create records into"
+}
+
+variable "license_file" {
+  type        = string
+  description = "Replicated license file"
+}
+
 variable "project" {
   type        = string
   description = "Name of the project to deploy into"

--- a/examples/root-example/variables.tf
+++ b/examples/root-example/variables.tf
@@ -1,0 +1,10 @@
+variable "project" {
+  type        = "string"
+  description = "Name of the project to deploy into"
+}
+
+variable "region" {
+  type        = "string"
+  description = "The region to install into."
+  default     = "us-central1"
+}

--- a/examples/root-example/variables.tf
+++ b/examples/root-example/variables.tf
@@ -1,10 +1,10 @@
 variable "project" {
-  type        = "string"
+  type        = string
   description = "Name of the project to deploy into"
 }
 
 variable "region" {
-  type        = "string"
+  type        = string
   description = "The region to install into."
   default     = "us-central1"
 }

--- a/examples/root-example/versions.tf
+++ b/examples/root-example/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = "~> 0.12.0"
+}

--- a/modules/cluster/outputs.tf
+++ b/modules/cluster/outputs.tf
@@ -1,6 +1,8 @@
 output "installer_dashboard_url" {
   description = "The URL to access the installer dashboard."
-  value       = "https://${google_compute_instance.primary[0].network_interface[0].access_config[0].nat_ip}:8800"
+  value = length(google_compute_instance.primary) > 0 ? (
+    "https://${google_compute_instance.primary[0].network_interface[0].access_config[0].nat_ip}:8800"
+  ) : ""
 }
 
 output "application_endpoints" {

--- a/modules/cluster/outputs.tf
+++ b/modules/cluster/outputs.tf
@@ -1,5 +1,8 @@
 output "installer_dashboard_url" {
   description = "The URL to access the installer dashboard."
+  # This conditional logic prevents an invalid index error when the value is evaluated after
+  # google_compute_instance.primary is destroyed. An example of this scenario is when a destroy process is resumed
+  # after recovering from an error.
   value = length(google_compute_instance.primary) > 0 ? (
     "https://${google_compute_instance.primary[0].network_interface[0].access_config[0].nat_ip}:8800"
   ) : ""


### PR DESCRIPTION
## Background

This branch is primarily focused on updating root-example to be compatible with the re-rolled module, but it also documents the required GCP permissions and fixes a bug with the `installer_dashboard_url` output.


Relates to #38.


## How Has This Been Tested

I created and destroyed root-example.

### Test Configuration

* Terraform Version: 0.12.19

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media.giphy.com/media/l0ErK5H6exTmBN7ri/giphy.gif)
