### PR TITLE
Depend on network resource rather than data source

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -86,6 +86,8 @@ module "cluster" {
   prefix     = var.prefix
 
   project  = var.project
+  region   = var.region
+  subnet   = module.vpc.subnet_name
 
   cluster-config = module.cluster-config
 

--- a/main.tf
+++ b/main.tf
@@ -88,6 +88,7 @@ module "cluster" {
   project  = var.project
   region   = var.region
   subnet   = module.vpc.subnet_name
+  vpc_name = var.vpc_name
 
   cluster-config = module.cluster-config
 

--- a/main.tf
+++ b/main.tf
@@ -85,9 +85,7 @@ module "cluster" {
   install_id = local.install_id
   prefix     = var.prefix
 
-  project = var.project
-  region  = var.region
-  subnet  = module.vpc.subnet_name
+  project  = var.project
 
   cluster-config = module.cluster-config
 

--- a/main.tf
+++ b/main.tf
@@ -88,7 +88,7 @@ module "cluster" {
   project  = var.project
   region   = var.region
   subnet   = module.vpc.subnet_name
-  vpc_name = var.vpc_name
+  vpc_name = module.vpc.vpc_name
 
   cluster-config = module.cluster-config
 

--- a/modules/cluster/module-internal-lb.tf
+++ b/modules/cluster/module-internal-lb.tf
@@ -5,5 +5,6 @@ module "internal_lb" {
   region     = var.region
 
   subnet    = var.subnet
+  vpc_name  = var.vpc_name
   primaries = google_compute_instance_group.primaries.self_link
 }

--- a/modules/cluster/modules/internal_lb/main.tf
+++ b/modules/cluster/modules/internal_lb/main.tf
@@ -34,7 +34,7 @@ resource "google_compute_region_backend_service" "primaries" {
 
 resource "google_compute_forwarding_rule" "primaries" {
   name                  = "${var.prefix}primaries-lb-${var.install_id}"
-  network               = data.google_compute_subnetwork.internal.network
+  network               = var.vpc_name
   subnetwork            = data.google_compute_subnetwork.internal.self_link
   load_balancing_scheme = "INTERNAL"
   backend_service       = google_compute_region_backend_service.primaries.self_link
@@ -51,7 +51,7 @@ resource "google_compute_address" "internal" {
 
 resource "google_compute_forwarding_rule" "internal" {
   name                  = "${var.prefix}internal-lb-${var.install_id}"
-  network               = data.google_compute_subnetwork.internal.network
+  network               = var.vpc_name
   subnetwork            = data.google_compute_subnetwork.internal.self_link
   load_balancing_scheme = "INTERNAL"
   backend_service       = google_compute_region_backend_service.internal.self_link
@@ -81,7 +81,7 @@ resource "google_compute_health_check" "tcp" {
 
 resource "google_compute_firewall" "internal-ilb-fw" {
   name    = "${var.prefix}internal-lb-fw-${var.install_id}"
-  network = data.google_compute_subnetwork.internal.network
+  network = var.vpc_name
 
   allow {
     protocol = "tcp"
@@ -93,7 +93,7 @@ resource "google_compute_firewall" "internal-ilb-fw" {
 
 resource "google_compute_firewall" "internal-hc" {
   name    = "${var.prefix}internal-lb-hc-${var.install_id}"
-  network = data.google_compute_subnetwork.internal.network
+  network = var.vpc_name
 
   allow {
     protocol = "tcp"

--- a/modules/cluster/modules/internal_lb/variables.tf
+++ b/modules/cluster/modules/internal_lb/variables.tf
@@ -24,3 +24,7 @@ variable "prefix" {
   default     = "tfe-"
 }
 
+variable "vpc_name" {
+  type        = string
+  description = "Name of Google Compute Network to attach to resources"
+}

--- a/modules/cluster/primary.tf
+++ b/modules/cluster/primary.tf
@@ -67,14 +67,10 @@ resource "google_compute_instance_group" "primaries" {
   depends_on = [google_compute_instance.primary]
 }
 
-data "google_compute_subnetwork" "internal" {
-  name = var.subnet
-}
-
 resource "google_compute_network_endpoint_group" "https" {
   name         = "${var.prefix}primary-cluster-${var.install_id}"
   subnetwork   = var.subnet
-  network      = data.google_compute_subnetwork.internal.network
+  network      = var.vpc_name
   default_port = "443"
   zone         = local.zone
 }
@@ -88,4 +84,3 @@ resource "google_compute_network_endpoint" "https" {
   ip_address = google_compute_instance.primary[count.index].network_interface[0].network_ip
   zone       = local.zone
 }
-

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -4,7 +4,7 @@ locals {
   internal_airgap_url             = "http://${module.internal_lb.address}:${local.assistant_port}/setup-files/replicated.tar.gz?token=${random_string.setup_token.result}"
 }
 
-### 
+###
 
 variable "install_id" {
   type        = string
@@ -113,6 +113,11 @@ variable "license_file" {
 variable "project" {
   type        = string
   description = "Name of the project to deploy into"
+}
+
+variable "vpc_name" {
+  type        = string
+  description = "Name of Google Compute Network to attach to resources"
 }
 
 ###################################################
@@ -250,4 +255,3 @@ resource "random_string" "setup_token" {
   upper   = false
   special = false
 }
-


### PR DESCRIPTION
## Background

This branch replaces the use of data sources with a direct resource reference to provide the network name to different resources. Resources which depend on data sources for the network name can cause the following error upon destroy:
> "network": required field is not set


Relates to #38.


## How Has This Been Tested

After making this change, I was able to create and destroy root-example without receiving the required field error.

### Test Configuration

* Terraform Version: 0.12.20

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media.giphy.com/media/9rczpmqTPexXJQsiAh/giphy.gif)
