### PR TITLE
Replace subnet data sources with resource references

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -85,9 +85,9 @@ module "cluster" {
   install_id = local.install_id
   prefix     = var.prefix
 
-  project  = var.project
-  region   = var.region
-  subnet   = module.vpc.subnet
+  project = var.project
+  region  = var.region
+  subnet  = module.vpc.subnet
 
   cluster-config = module.cluster-config
 

--- a/main.tf
+++ b/main.tf
@@ -87,8 +87,7 @@ module "cluster" {
 
   project  = var.project
   region   = var.region
-  subnet   = module.vpc.subnet_name
-  vpc_name = module.vpc.vpc_name
+  subnet   = module.vpc.subnet
 
   cluster-config = module.cluster-config
 

--- a/modules/cluster/module-internal-lb.tf
+++ b/modules/cluster/module-internal-lb.tf
@@ -5,6 +5,5 @@ module "internal_lb" {
   region     = var.region
 
   subnet    = var.subnet
-  vpc_name  = var.vpc_name
   primaries = google_compute_instance_group.primaries.self_link
 }

--- a/modules/cluster/modules/internal_lb/proxy.tf
+++ b/modules/cluster/modules/internal_lb/proxy.tf
@@ -24,7 +24,7 @@ resource "google_compute_instance_template" "haproxy" {
   }
 
   network_interface {
-    subnetwork = var.subnet
+    subnetwork = var.subnet.self_link
   }
 
   metadata_startup_script = templatefile("${path.module}/files/setup-proxy.sh", {

--- a/modules/cluster/modules/internal_lb/variables.tf
+++ b/modules/cluster/modules/internal_lb/variables.tf
@@ -4,8 +4,8 @@ variable "install_id" {
 }
 
 variable "subnet" {
-  type        = string
-  description = "GCP Subnetwork Name for Load Balancer"
+  type        = object({ ip_cidr_range = string, network = string, self_link = string })
+  description = "GCP Subnetwork for Load Balancer"
 }
 
 variable "region" {
@@ -22,9 +22,4 @@ variable "prefix" {
   type        = string
   description = "Prefix for resources"
   default     = "tfe-"
-}
-
-variable "vpc_name" {
-  type        = string
-  description = "Name of Google Compute Network to attach to resources"
 }

--- a/modules/cluster/primary.tf
+++ b/modules/cluster/primary.tf
@@ -25,7 +25,7 @@ resource "google_compute_instance" "primary" {
   }
 
   network_interface {
-    subnetwork = var.subnet
+    subnetwork = var.subnet.self_link
 
     access_config {
       // public IP
@@ -69,8 +69,8 @@ resource "google_compute_instance_group" "primaries" {
 
 resource "google_compute_network_endpoint_group" "https" {
   name         = "${var.prefix}primary-cluster-${var.install_id}"
-  subnetwork   = var.subnet
-  network      = var.vpc_name
+  subnetwork   = var.subnet.self_link
+  network      = var.subnet.network
   default_port = "443"
   zone         = local.zone
 }

--- a/modules/cluster/secondary.tf
+++ b/modules/cluster/secondary.tf
@@ -13,7 +13,7 @@ resource "google_compute_instance_template" "secondary" {
   }
 
   network_interface {
-    subnetwork = var.subnet
+    subnetwork = var.subnet.self_link
 
     access_config {
       // Public IP

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -12,8 +12,8 @@ variable "install_id" {
 }
 
 variable "subnet" {
-  type        = string
-  description = "name of the subnet to install into"
+  type        = object({ ip_cidr_range = string, network = string, self_link = string })
+  description = "GCP Subnetwork to attach resources to"
 }
 
 variable "prefix" {
@@ -113,11 +113,6 @@ variable "license_file" {
 variable "project" {
   type        = string
   description = "Name of the project to deploy into"
-}
-
-variable "vpc_name" {
-  type        = string
-  description = "Name of Google Compute Network to attach to resources"
 }
 
 ###################################################

--- a/modules/vpc/outputs.tf
+++ b/modules/vpc/outputs.tf
@@ -21,3 +21,7 @@ output "network_url" {
 output "subnetwork_url" {
   value = google_compute_network.tfe_vpc.self_link
 }
+
+output "subnet" {
+  value = google_compute_subnetwork.tfe_subnet
+}


### PR DESCRIPTION
## Background

Similar to #46, this commit replaces the remaining instances of subnetwork
data sources with a reference to the subnetwork resource to prevent the following
error on destroy:

> Error: Null value found in list
>
>  on ../../modules/cluster/modules/internal_lb/main.tf line 91, in
> resource "google_compute_firewall" "internal-ilb-fw":
>  91:   source_ranges =
> [data.google_compute_subnetwork.internal.ip_cidr_range]
>
> Null values are not allowed for this attribute value.


Relates to #46, #38 


## How Has This Been Tested

Provisioned and destroyed root-example without experiencing the previously mentioned error.

### Test Configuration

* Terraform Version: 0.12.20

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media.giphy.com/media/lVBtp4SRW6rvDHf1b6/giphy.gif)
