### PR TITLE
fixed syntax error

### DIFF
--- a/modules/lb/forwarding_rule.tf
+++ b/modules/lb/forwarding_rule.tf
@@ -13,5 +13,5 @@ resource "google_compute_target_https_proxy" "tfe" {
   ssl_certificates = ["${var.cert}"]
   ssl_policy       = "${var.sslpolicy}"
 
-  #ssl_certificates = ["${file("${path.module}/${var.cert})"]
+  #ssl_certificates = ["${file("${path.module}/${var.cert}")}"]
 }


### PR DESCRIPTION
## Background

There's a syntax error in variable ssl_certificates.

## How Has This Been Tested

Uncomment and run terraform init.

### Test Configuration

* Terraform Version: 0.12.20
* Any additional relevant variables:
