### PR TITLE
Allow overriding project for managed dns zone

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,4 +1,4 @@
 locals {
-  dns_project = var.dns_project != "" ? var.dns_project : var.project
-  install_id  = var.install_id != "" ? var.install_id : random_string.install_id.result
+  install_id           = var.install_id != "" ? var.install_id : random_string.install_id.result
+  rendered_dns_project = var.dns_project != "" ? var.dns_project : var.project
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,3 +1,4 @@
 locals {
-  install_id = var.install_id != "" ? var.install_id : random_string.install_id.result
+  dns_project = var.dns_project != "" ? var.dns_project : var.project
+  install_id  = var.install_id != "" ? var.install_id : random_string.install_id.result
 }

--- a/main.tf
+++ b/main.tf
@@ -137,7 +137,7 @@ module "dns-primaries" {
   install_id = local.install_id
   prefix     = var.prefix
 
-  project   = var.project
+  project   = local.dns_project
   dnszone   = var.dnszone
   primaries = module.cluster.primary_external_addresses
 }
@@ -169,6 +169,7 @@ module "dns" {
   prefix     = var.prefix
 
   address  = module.loadbalancer.address
+  project  = local.dns_project
   dnszone  = var.dnszone
   hostname = var.hostname
 }

--- a/main.tf
+++ b/main.tf
@@ -137,7 +137,7 @@ module "dns-primaries" {
   install_id = local.install_id
   prefix     = var.prefix
 
-  project   = local.dns_project
+  project   = local.rendered_dns_project
   dnszone   = var.dnszone
   primaries = module.cluster.primary_external_addresses
 }
@@ -169,7 +169,7 @@ module "dns" {
   prefix     = var.prefix
 
   address  = module.loadbalancer.address
-  project  = local.dns_project
+  project  = local.rendered_dns_project
   dnszone  = var.dnszone
   hostname = var.hostname
 }

--- a/modules/dns/main.tf
+++ b/modules/dns/main.tf
@@ -1,11 +1,13 @@
 data "google_dns_managed_zone" "dnszone" {
-  name = var.dnszone
+  name    = var.dnszone
+  project = var.project
 }
 
 resource "google_dns_record_set" "hostname" {
   name = "${var.hostname}.${data.google_dns_managed_zone.dnszone.dns_name}"
   type = "A"
   ttl  = 300
+  project = var.project
 
   managed_zone = data.google_dns_managed_zone.dnszone.name
 

--- a/modules/dns/variables.tf
+++ b/modules/dns/variables.tf
@@ -23,3 +23,8 @@ variable "address" {
   type        = string
   description = "IP Address to associate with the hostname"
 }
+
+variable "project" {
+  type        = string
+  description = "GCP Project to find the DNS Zone"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -13,6 +13,12 @@ variable "dnszone" {
   description = "Name of the managed dns zone to create records into"
 }
 
+variable "dns_project" {
+  type        = string
+  description = "GCP Project to find the DNS Zone, defaults to var.project"
+  default     = ""
+}
+
 variable "license_file" {
   type        = string
   description = "Replicated license file"


### PR DESCRIPTION
## Background

Allow managed dns zone to be in another project.

## How Has This Been Tested

Installed TFE from scratch with this branch for both cases of single project and separate dns project.

### Test Configuration

* Terraform Version: 0.12.20