### PR TITLE
Update doc-gen.sh script to newer binary

### DIFF
--- a/.scripts/doc-gen.sh
+++ b/.scripts/doc-gen.sh
@@ -4,10 +4,10 @@ set -e
 
 BINARY_DIR=./work
 BINARY_FILE="${BINARY_DIR}/terraform-docs"
-BINARY_VERSION=0.6.0
+BINARY_VERSION=0.8.2
 BINARY_URL_PREFIX="https://github.com/segmentio/terraform-docs/releases/download/v${BINARY_VERSION}/terraform-docs-v${BINARY_VERSION}"
 
-DOCS_CMDS="--sort-inputs-by-required --with-aggregate-type-defaults markdown table"
+DOCS_CMDS="--sort-by-required --no-header markdown table"
 DOCS_DIR=docs
 
 VARS_TF=variables.tf
@@ -25,8 +25,8 @@ function setup {
         elif [[ "$OSTYPE" == "darwin"* ]]; then
             BINARY_URL="${BINARY_URL_PREFIX}-darwin-amd64"
         else
-            echo "Please run this in either a Linux or Mac environment."     
-            exit 1  
+            echo "Please run this in either a Linux or Mac environment."
+            exit 1
         fi
         echo "Downloading ${BINARY_URL}"
         curl -L -o "${BINARY_FILE}" "${BINARY_URL}"
@@ -41,8 +41,8 @@ function main_docs {
 
     echo -e "# Terraform Enterprise: Clustering\n" | tee "${DOCS_DIR}/${INS_MD}" "${DOCS_DIR}/${OUTS_MD}" &> /dev/null
 
-    eval "${BINARY_FILE} ${DOCS_CMDS} ${VARS_TF}"  >> "${DOCS_DIR}/${INS_MD}"
-    eval "${BINARY_FILE} ${DOCS_CMDS} ${OUTS_TF}" >> "${DOCS_DIR}/${OUTS_MD}"
+    eval "${BINARY_FILE} ${DOCS_CMDS} --no-outputs --no-providers" . >> "${DOCS_DIR}/${INS_MD}"
+    eval "${BINARY_FILE} ${DOCS_CMDS} --no-inputs --no-providers" . >> "${DOCS_DIR}/${OUTS_MD}"
 
 }
 
@@ -51,11 +51,11 @@ function module_docs {
     if test -d ./modules; then
         for dir in ./modules/*; do
             mkdir -p "${dir}/${DOCS_DIR}"
-            
+
             echo -e "# Terraform Enterprise: Clustering\n" | tee "${dir}/${DOCS_DIR}/${INS_MD}" "${dir}/${DOCS_DIR}/${OUTS_MD}" &> /dev/null
 
-            eval "${BINARY_FILE} ${DOCS_CMDS} ${dir}/${VARS_TF}"  >> "${dir}/${DOCS_DIR}/${INS_MD}"
-            eval "${BINARY_FILE} ${DOCS_CMDS} ${dir}/${OUTS_TF}" >> "${dir}/${DOCS_DIR}/${OUTS_MD}"
+            eval "${BINARY_FILE} ${DOCS_CMDS} --no-outputs --no-providers ${dir}"  >> "${dir}/${DOCS_DIR}/${INS_MD}"
+            eval "${BINARY_FILE} ${DOCS_CMDS} --no-inputs --no-providers ${dir}" >> "${dir}/${DOCS_DIR}/${OUTS_MD}"
         done
     else
         echo "No modules directory, skipping."
@@ -66,6 +66,7 @@ function module_docs {
 setup
 main_docs
 module_docs
+
 
 
 


### PR DESCRIPTION
## Background

Google version of what I did over in hashicorp/terraform-aws-terraform-enterprise#67 .

Too link didn't click; This script updates the doc-gen.sh script with a newer binary and updates the flags to match as the older one was breaking. 

In the case of this one and not the others I decided to not generate new docs as https://github.com/hashicorp/terraform-google-terraform-enterprise/pull/38 is still in flight and changes things significantly. 

We will want to cherry pick this change into #38. 

## How Has This Been Tested

Confirmed it ran locally, but then discarded the results so it could be better applied to the reroll. 

## This PR makes me feel

![Concentrating cartoon animal writing on paper](https://media.giphy.com/media/xFnxVuOe6jAbqgy9uR/giphy.gif)
