### PR TITLE
Instance types

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,4 +1,6 @@
 locals {
-  install_id           = var.install_id != "" ? var.install_id : random_string.install_id.result
-  rendered_dns_project = var.dns_project != "" ? var.dns_project : var.project
+  install_id                        = var.install_id != "" ? var.install_id : random_string.install_id.result
+  rendered_dns_project              = var.dns_project != "" ? var.dns_project : var.project
+  rendered_secondary_machine_type   = var.secondary_machine_type != "" ? var.secondary_machine_type : var.primary_machine_type
+  rendered_secondary_boot_disk_size = var.secondary_boot_disk_size != "" ? var.secondary_boot_disk_size : var.primary_boot_disk_size
 }

--- a/main.tf
+++ b/main.tf
@@ -40,6 +40,7 @@ module "postgres" {
 
   postgresql_availability_type = var.postgresql_availability_type
   postgresql_backup_start_time = var.postgresql_backup_start_time
+  postgresql_machine_type      = var.postgresql_machine_type
 }
 
 # Create a GCP service account to access our GCS bucket
@@ -113,6 +114,11 @@ module "cluster" {
   postgresql_database = module.postgres.database_name
   postgresql_user     = module.postgres.user
   postgresql_password = module.postgres.password
+
+  primary_machine_type     = var.primary_machine_type
+  secondary_machine_type   = var.rendered_secondary_machine_type
+  primary_boot_disk_size   = var.primary_boot_disk_size
+  secondary_boot_disk_size = var.rendered_secondary_boot_disk_size
 
   max_secondaries          = var.max_secondaries
   min_secondaries          = var.min_secondaries

--- a/modules/cluster/primary.tf
+++ b/modules/cluster/primary.tf
@@ -19,7 +19,7 @@ resource "google_compute_instance" "primary" {
   boot_disk {
     initialize_params {
       image = var.image_family
-      size  = var.boot_disk_size
+      size  = var.primary_boot_disk_size
       type  = "pd-ssd"
     }
   }

--- a/modules/cluster/secondary.tf
+++ b/modules/cluster/secondary.tf
@@ -8,7 +8,7 @@ resource "google_compute_instance_template" "secondary" {
     source_image = var.image_family
     auto_delete  = true
     boot         = true
-    disk_size_gb = var.boot_disk_size
+    disk_size_gb = var.secondary_boot_disk_size
     disk_type    = "pd-ssd"
   }
 

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -1,6 +1,7 @@
 locals {
-  assistant_port                  = 23010
-  rendered_secondary_machine_type = var.secondary_machine_type != "" ? var.secondary_machine_type : var.primary_machine_type
+  assistant_port                    = 23010
+  rendered_secondary_machine_type   = var.secondary_machine_type != "" ? var.secondary_machine_type : var.primary_machine_type
+  rendered_secondary_boot_disk_size = var.secondary_boot_disk_size != "" ? var.secondary_boot_disk_size : var.primary_boot_disk_size
 }
 
 ###
@@ -43,14 +44,14 @@ variable "labels" {
 
 variable "primary_machine_type" {
   type        = string
-  description = "Type of machine to use"
+  description = "Type of machine to use for primary instances"
   default     = "n1-standard-4"
 }
 
 variable "secondary_machine_type" {
   type        = string
-  description = "Type of machine to use for secondary nodes, if unset, will default to primary_machine_type"
-  default     = "n1-standard-4"
+  description = "Type of machine to use for secondary instances"
+  default     = ""
 }
 
 variable "image_family" {
@@ -59,10 +60,16 @@ variable "image_family" {
   default     = "ubuntu-1804-lts"
 }
 
-variable "boot_disk_size" {
+variable "primary_boot_disk_size" {
   type        = string
-  description = "The size of the boot disk to use for the instances"
-  default     = 40
+  description = "The size of the boot disk to use for primary instances"
+  default     = "40"
+}
+
+variable "secondary_boot_disk_size" {
+  type        = string
+  description = "The size of the boot disk to use for secondary instances"
+  default     = ""
 }
 
 variable "ca_bundle_url" {

--- a/modules/dns/main.tf
+++ b/modules/dns/main.tf
@@ -4,9 +4,9 @@ data "google_dns_managed_zone" "dnszone" {
 }
 
 resource "google_dns_record_set" "hostname" {
-  name = "${var.hostname}.${data.google_dns_managed_zone.dnszone.dns_name}"
-  type = "A"
-  ttl  = 300
+  name    = "${var.hostname}.${data.google_dns_managed_zone.dnszone.dns_name}"
+  type    = "A"
+  ttl     = 300
   project = var.project
 
   managed_zone = data.google_dns_managed_zone.dnszone.name

--- a/modules/postgres/main.tf
+++ b/modules/postgres/main.tf
@@ -27,8 +27,9 @@ resource "google_sql_database_instance" "tfe" {
 
   settings {
     # Second-generation instance tiers are based on the machine
-    # type. See argument reference below.
-    tier              = var.postgresql_machinetype
+    # type. Postgres supports only shared-core machine types and
+    # custom machine types.
+    tier              = var.postgresql_machine_type
     availability_type = var.postgresql_availability_type
 
     ip_configuration {

--- a/modules/postgres/variables.tf
+++ b/modules/postgres/variables.tf
@@ -20,9 +20,9 @@ variable "labels" {
   default     = {}
 }
 
-variable "postgresql_machinetype" {
+variable "postgresql_machine_type" {
   type        = string
-  description = "Machine type to use for Postgres Database"
+  description = "Type of machine to use for Postgres Database instance"
   default     = "db-custom-2-13312"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -52,6 +52,12 @@ variable "prefix" {
 # Postgresql options
 ###################################################
 
+variable "postgresql_machine_type" {
+  type        = string
+  description = "Type of machine to use for Postgres Database instance"
+  default     = "db-custom-2-13312"
+}
+
 variable "postgresql_availability_type" {
   type        = string
   description = "This specifies whether a PostgreSQL instance should be set up for high availability (REGIONAL) or single zone (ZONAL)"
@@ -61,6 +67,34 @@ variable "postgresql_availability_type" {
 variable "postgresql_backup_start_time" {
   type        = string
   description = "HH:MM format time indicating when backup configuration starts."
+  default     = ""
+}
+
+###################################################
+# Instance sizing
+###################################################
+
+variable "primary_machine_type" {
+  type        = string
+  description = "Type of machine to use for primary instances"
+  default     = "n1-standard-4"
+}
+
+variable "secondary_machine_type" {
+  type        = string
+  description = "Type of machine to use for secondary instances, if unset, will default to primary_machine_type"
+  default     = ""
+}
+
+variable "primary_boot_disk_size" {
+  type        = string
+  description = "The size of the boot disk to use for the primary instances"
+  default     = "40"
+}
+
+variable "secondary_boot_disk_size" {
+  type        = string
+  description = "The size of the boot disk to use for the secondary instances, if unset, will default to primary_boot_disk_size"
   default     = ""
 }
 


### PR DESCRIPTION
## Background

Related to a support request, it's been recommended to us to change the machine type of our cluster instances and this is to expose those variables.

Right now I expect this will require some iteration but I'm looking for feedback on expectations / standards.

> Any nested module with a README.md is considered usable by an external user. If a README doesn't exist, it is considered for internal use only.

From the documentation, I would expect the `postgres` module to be meant only for use within this context whereas someone could be expected to deep link to the `cluster` module. Does that mean that default values don't need to be duplicated in the top level `variables.tf` as well as that in the child module? Keeping them in sync and updated in both places seems error prone and having incorrect values could be confusing.

This seems especially important with the "rendered" variables.

## How Has This Been Tested

None yet, if we can agree on a candidate, I can perform tests and report on those then.

### Test Configuration

N/A

## This PR makes me feel

![](https://odditymall.com/includes/content/upload/folded-book-art-2255.gif)
