### PR TITLE
Add labels argument to root and internal-load-balancer

### DIFF
--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -7,5 +7,6 @@
 | cloud\_init\_license\_file | The pathname of a Replicated license file for the application. | `string` | n/a | yes |
 | dns\_managed\_zone | The name of the managed DNS zone in which the application will be accessible. | `string` | n/a | yes |
 | dns\_managed\_zone\_dns\_name | The fully qualified DNS name of the managed zone set by var.dns\_managed\_zone. | `string` | n/a | yes |
+| labels | A collection of labels which will be applied to resources. | `map(string)` | `{}` | no |
 | prefix | The prefix which will be prepended to the names of resources. | `string` | `"tfe-"` | no |
 

--- a/main.tf
+++ b/main.tf
@@ -3,6 +3,8 @@ module "storage" {
   source = "./modules/storage"
 
   prefix = var.prefix
+
+  labels = var.labels
 }
 
 # Create a service account which will be used to access the storage bucket.
@@ -35,6 +37,8 @@ module "postgresql" {
 
   prefix                = var.prefix
   vpc_network_self_link = module.vpc.network.self_link
+
+  labels = var.labels
 }
 
 # Generate the application configuration.
@@ -69,6 +73,8 @@ module "primary_cluster" {
   vpc_network_self_link    = module.vpc.network.self_link
   vpc_subnetwork_project   = module.vpc.subnetwork.project
   vpc_subnetwork_self_link = module.vpc.subnetwork.self_link
+
+  labels = var.labels
 }
 
 # Create the primary cluster internal load balancer.
@@ -81,6 +87,8 @@ module "internal_load_balancer" {
   vpc_subnetwork_ip_cidr_range             = module.vpc.subnetwork.ip_cidr_range
   vpc_subnetwork_project                   = module.vpc.subnetwork.project
   vpc_subnetwork_self_link                 = module.vpc.subnetwork.self_link
+
+  labels = var.labels
 }
 
 # Create the secondary cluster.
@@ -92,6 +100,8 @@ module "secondary_cluster" {
   vpc_network_self_link    = module.vpc.network.self_link
   vpc_subnetwork_project   = module.vpc.subnetwork.project
   vpc_subnetwork_self_link = module.vpc.subnetwork.self_link
+
+  labels = var.labels
 }
 
 # Create an external load balancer which directs traffic to the primary cluster.

--- a/modules/internal-load-balancer/docs/inputs.md
+++ b/modules/internal-load-balancer/docs/inputs.md
@@ -11,6 +11,7 @@
 | vpc\_subnetwork\_self\_link | The self link of the subnetwork to which resources will be attached. The subnetwork must be part of var.vpc\_network\_self\_link. | `string` | n/a | yes |
 | cluster\_assistant\_port | The port of the Cluster Assistant. | `number` | `23010` | no |
 | k8s\_api\_port | The port of the Kubernetes API. | `number` | `6443` | no |
+| labels | A collection of labels which will be applied to resources. | `map(string)` | `{}` | no |
 | ports | Only packets addressed to these ports will be forwarded through the internal load balancer. var.k8s\_api\_port will be added to this list. | `list(number)` | <pre>[<br>  80,<br>  443,<br>  23010<br>]</pre> | no |
 | prefix | Prefix for resources | `string` | `"tfe-"` | no |
 

--- a/modules/internal-load-balancer/docs/inputs.md
+++ b/modules/internal-load-balancer/docs/inputs.md
@@ -11,7 +11,7 @@
 | vpc\_subnetwork\_self\_link | The self link of the subnetwork to which resources will be attached. The subnetwork must be part of var.vpc\_network\_self\_link. | `string` | n/a | yes |
 | cluster\_assistant\_port | The port of the Cluster Assistant. | `number` | `23010` | no |
 | k8s\_api\_port | The port of the Kubernetes API. | `number` | `6443` | no |
-| labels | A collection of labels which will be applied to resources. | `map(string)` | `{}` | no |
+| labels | A collection of labels which will be applied to the compute instances. | `map(string)` | `{}` | no |
 | ports | Only packets addressed to these ports will be forwarded through the internal load balancer. var.k8s\_api\_port will be added to this list. | `list(number)` | <pre>[<br>  80,<br>  443,<br>  23010<br>]</pre> | no |
 | prefix | Prefix for resources | `string` | `"tfe-"` | no |
 

--- a/modules/internal-load-balancer/main.tf
+++ b/modules/internal-load-balancer/main.tf
@@ -72,6 +72,7 @@ resource "google_compute_instance_template" "node" {
   can_ip_forward       = true
   description          = "The template for the node compute instances of the internal load balancer."
   instance_description = "A node compute instance of the internal load balancer."
+  labels               = var.labels
   metadata_startup_script = templatefile(
     "${path.module}/templates/setup-proxy.tmpl",
     {

--- a/modules/internal-load-balancer/variables.tf
+++ b/modules/internal-load-balancer/variables.tf
@@ -6,7 +6,7 @@ variable "cluster_assistant_port" {
 
 variable "labels" {
   default     = {}
-  description = "A collection of labels which will be applied to resources."
+  description = "A collection of labels which will be applied to the compute instances."
   type        = map(string)
 }
 

--- a/modules/internal-load-balancer/variables.tf
+++ b/modules/internal-load-balancer/variables.tf
@@ -4,6 +4,12 @@ variable "cluster_assistant_port" {
   default     = 23010
 }
 
+variable "labels" {
+  default     = {}
+  description = "A collection of labels which will be applied to resources."
+  type        = map(string)
+}
+
 variable "k8s_api_port" {
   type        = number
   description = "The port of the Kubernetes API."

--- a/modules/postgresql/docs/inputs.md
+++ b/modules/postgresql/docs/inputs.md
@@ -9,7 +9,7 @@
 | prefix | The prefix which will be prepended to the names of resources. | `string` | n/a | yes |
 | vpc\_network\_self\_link | The self link of the network to which resources will be attached. | `string` | n/a | yes |
 | availability\_type | A specifier which determines if the database compute instance will be set up for high availability (REGIONAL) or single zone (ZONAL). | `string` | `"ZONAL"` | no |
-| labels | A collection of labels which will be applied to resources. | `map(string)` | `{}` | no |
+| labels | A collection of labels which will be applied to the database compute instance. | `map(string)` | `{}` | no |
 | machine\_type | The identifier of the set of virtualized hardware resources which will be available to the database compute instance. | `string` | `"db-custom-2-13312"` | no |
 | name | The name of the database which will be used to store application data. | `string` | `"tfe"` | no |
 | username | The username which will be used for authentication with the database. | `string` | `"tfe"` | no |

--- a/modules/postgresql/variables.tf
+++ b/modules/postgresql/variables.tf
@@ -12,7 +12,7 @@ variable "backup_start_time" {
 
 variable "labels" {
   default     = {}
-  description = "A collection of labels which will be applied to resources."
+  description = "A collection of labels which will be applied to the database compute instance."
   type        = map(string)
 }
 

--- a/modules/storage/docs/inputs.md
+++ b/modules/storage/docs/inputs.md
@@ -6,5 +6,5 @@
 |------|-------------|------|---------|:-----:|
 | location | The name of the storage location in which the bucket will be created. | `string` | n/a | yes |
 | prefix | The prefix which will be prepended to the names of resources. | `string` | n/a | yes |
-| labels | A collection of labels which will be applied to resources. | `map(string)` | `{}` | no |
+| labels | A collection of labels which will be applied to the storage bucket. | `map(string)` | `{}` | no |
 

--- a/modules/storage/variables.tf
+++ b/modules/storage/variables.tf
@@ -1,6 +1,6 @@
 variable "labels" {
   default     = {}
-  description = "A collection of labels which will be applied to resources."
+  description = "A collection of labels which will be applied to the storage bucket."
   type        = map(string)
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -13,6 +13,12 @@ variable "dns_managed_zone_dns_name" {
   type        = string
 }
 
+variable "labels" {
+  default     = {}
+  description = "A collection of labels which will be applied to resources."
+  type        = map(string)
+}
+
 variable "prefix" {
   default     = "tfe-"
   description = "The prefix which will be prepended to the names of resources."


### PR DESCRIPTION
## Background

Users of the module require the ability to apply labels to the resources which are created. I audited all of the resources and verified that the `f-reroll` branch currently supports labelling of all applicable resources except for the internal-load-balancer compute instance template. This branch adds the missing labels to that template and a root variable to assign labels globally.

Relates #38 

## How Has This Been Tested

I adjusted the root module example to source the root module and verified that a plan could be generated.

### Test Configuration

* Terraform Version: 0.12.17

## This PR makes me feel

![That's all Folks](https://media2.giphy.com/media/lD76yTC5zxZPG/giphy.gif?cid=5a38a5a22758de8cfaa95c5939b20a7d21a864fabd39a4db&rid=giphy.gif)
