### PR TITLE
Remove public IP addresses from compute instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,18 @@ reproduced when using the submodules.
 
 *Reading the outputs*
 
+Because the compute instances are created without external IP
+addresses, a method alternative to a direct [SSH][ssh] connection must
+be used to establish a remote connection with any of the instances. Two
+simple alternative methods are to use
+[SSH from the browser][ssh-in-browser] or [Identity-Aware Proxy][iap].
+
+```sh
+~/work$ gcloud compute ssh <tfe-instance> --tunnel-through-iap
+```
+
+*Example of connecting to an instance through IAP*
+
 ## Support
 
 Any Enterprise questions should be directed to
@@ -127,7 +139,10 @@ Any Enterprise questions should be directed to
 [github-issues]: https://github.com/hashicorp/terraform-google-terraform-enterprise/issues
 [google-provider]: https://registry.terraform.io/providers/hashicorp/google
 [hashicorp-support]: https://support.hashicorp.com/
+[iap]: https://cloud.google.com/iap
 [quickstart]: https://github.com/hashicorp/terraform-google-terraform-enterprise-quickstart
+[ssh]: https://en.wikipedia.org/wiki/Secure_Shell
+[ssh-in-browser]: https://cloud.google.com/compute/docs/ssh-in-browser
 [tf-community-forum]: https://discuss.hashicorp.com/c/terraform-core
 [tf-install]: https://learn.hashicorp.com/terraform/getting-started/install
 [tf-module-version]: https://www.terraform.io/docs/configuration/modules.html#module-versions

--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -5,5 +5,6 @@
 | Name | Description |
 |------|-------------|
 | application\_url | The URL of the application. |
-| console\_password | The generated password for the management console. |
+| install\_dashboard\_password | The generated password for the install dashboard. |
+| install\_dashboard\_url | The URL of the install dashboard. |
 

--- a/examples/proxy/docs/inputs.md
+++ b/examples/proxy/docs/inputs.md
@@ -1,0 +1,12 @@
+# Terraform Enterprise: Clustering
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:-----:|
+| cloud\_init\_license\_file | The pathname of a Replicated license file for the application. | `string` | n/a | yes |
+| dns\_managed\_zone | The name of the managed DNS zone in which the application will be accessible. | `string` | n/a | yes |
+| dns\_managed\_zone\_dns\_name | The fully qualified DNS name of the managed zone set by var.dns\_managed\_zone. | `string` | n/a | yes |
+| labels | A collection of labels which will be applied to resources. | `map(string)` | `{}` | no |
+| prefix | The prefix which will be prepended to the names of resources. | `string` | `"tfeproxy-"` | no |
+

--- a/examples/proxy/docs/outputs.md
+++ b/examples/proxy/docs/outputs.md
@@ -6,4 +6,5 @@
 |------|-------------|
 | application\_url | The URL of the application. |
 | console\_password | The generated password for the management console. |
+| console\_url | The URL of the management console. |
 

--- a/examples/proxy/docs/outputs.md
+++ b/examples/proxy/docs/outputs.md
@@ -5,6 +5,6 @@
 | Name | Description |
 |------|-------------|
 | application\_url | The URL of the application. |
-| console\_password | The generated password for the management console. |
-| console\_url | The URL of the management console. |
+| install\_dashboard\_password | The generated password for the install dashboard. |
+| install\_dashboard\_url | The URL of the install dashboard. |
 

--- a/examples/proxy/main.tf
+++ b/examples/proxy/main.tf
@@ -72,6 +72,7 @@ module "cloud_init" {
   internal_load_balancer_in_address = module.internal_load_balancer.in_address.address
   license_file                      = var.cloud_init_license_file
   vpc_cluster_assistant_tcp_port    = module.vpc.cluster_assistant_tcp_port
+  vpc_install_dashboard_tcp_port    = module.vpc.install_dashboard_tcp_port
   vpc_kubernetes_tcp_port           = module.vpc.kubernetes_tcp_port
   proxy_url                         = module.proxy.url
 }
@@ -80,15 +81,15 @@ module "cloud_init" {
 module "primaries" {
   source = "hashicorp/terraform-enterprise/google//modules/primaries"
 
-  cloud_init_configs         = module.cloud_init.primaries_configs
-  prefix                     = var.prefix
-  service_account_email      = module.service_account.primaries.email
-  vpc_application_tcp_port   = module.vpc.application_tcp_port
-  vpc_kubernetes_tcp_port    = module.vpc.kubernetes_tcp_port
-  vpc_network_self_link      = module.vpc.network.self_link
-  vpc_replicated_ui_tcp_port = module.vpc.replicated_ui_tcp_port
-  vpc_subnetwork_project     = module.vpc.subnetwork.project
-  vpc_subnetwork_self_link   = module.vpc.subnetwork.self_link
+  cloud_init_configs             = module.cloud_init.primaries_configs
+  prefix                         = var.prefix
+  service_account_email          = module.service_account.primaries.email
+  vpc_application_tcp_port       = module.vpc.application_tcp_port
+  vpc_install_dashboard_tcp_port = module.vpc.install_dashboard_tcp_port
+  vpc_kubernetes_tcp_port        = module.vpc.kubernetes_tcp_port
+  vpc_network_self_link          = module.vpc.network.self_link
+  vpc_subnetwork_project         = module.vpc.subnetwork.project
+  vpc_subnetwork_self_link       = module.vpc.subnetwork.self_link
 
   labels = var.labels
 }
@@ -114,15 +115,15 @@ module "internal_load_balancer" {
 module "secondaries" {
   source = "hashicorp/terraform-enterprise/google//modules/secondaries"
 
-  cloud_init_config          = module.cloud_init.secondaries_config
-  prefix                     = var.prefix
-  service_account_email      = module.service_account.secondaries.email
-  vpc_application_tcp_port   = module.vpc.application_tcp_port
-  vpc_kubernetes_tcp_port    = module.vpc.kubernetes_tcp_port
-  vpc_network_self_link      = module.vpc.network.self_link
-  vpc_replicated_ui_tcp_port = module.vpc.replicated_ui_tcp_port
-  vpc_subnetwork_project     = module.vpc.subnetwork.project
-  vpc_subnetwork_self_link   = module.vpc.subnetwork.self_link
+  cloud_init_config              = module.cloud_init.secondaries_config
+  prefix                         = var.prefix
+  service_account_email          = module.service_account.secondaries.email
+  vpc_application_tcp_port       = module.vpc.application_tcp_port
+  vpc_install_dashboard_tcp_port = module.vpc.install_dashboard_tcp_port
+  vpc_kubernetes_tcp_port        = module.vpc.kubernetes_tcp_port
+  vpc_network_self_link          = module.vpc.network.self_link
+  vpc_subnetwork_project         = module.vpc.subnetwork.project
+  vpc_subnetwork_self_link       = module.vpc.subnetwork.self_link
 
   labels = var.labels
 }
@@ -138,6 +139,7 @@ module "external_load_balancer" {
   ssl_policy_self_link                              = module.ssl.policy.self_link
   vpc_address                                       = module.vpc.external_load_balancer_address.address
   vpc_application_tcp_port                          = module.vpc.application_tcp_port
+  vpc_install_dashboard_tcp_port                    = module.vpc.install_dashboard_tcp_port
 }
 
 # Configures DNS entries for the load balancer.

--- a/examples/proxy/outputs.tf
+++ b/examples/proxy/outputs.tf
@@ -1,17 +1,17 @@
 output "application_url" {
-  value = module.dns.application_url
+  value = "https://${module.dns.fqdn}/"
 
   description = "The URL of the application."
 }
 
-output "console_password" {
-  value = module.cloud_init.console_password
+output "install_dashboard_password" {
+  value = module.cloud_init.install_dashboard_password
 
-  description = "The generated password for the management console."
+  description = "The generated password for the install dashboard."
 }
 
-output "console_url" {
-  value = module.primaries.console_url
+output "install_dashboard_url" {
+  value = "https://${module.dns.fqdn}:${module.vpc.install_dashboard_tcp_port}/"
 
-  description = "The URL of the management console."
+  description = "The URL of the install dashboard."
 }

--- a/examples/rhel-production-example/README.md
+++ b/examples/rhel-production-example/README.md
@@ -46,14 +46,14 @@ You'll need to update the following settings to your set up:
 * license_file: your TFE license
 * encryption_password: In order to re-use external services, you need to set/pass and encryption password
 * image_family: the name of the RHEL image to use - 7.6 is the latest currently supported
-* gcs_bucket: name of the bucket to use. This example assume the bucket resides in the same project. 
+* gcs_bucket: name of the bucket to use. This example assume the bucket resides in the same project.
 * postgresql_address: Connection address for the postgresql server
 * postgresql_database: Name of the database to use
 * postgresql_user: Username to connect with
 * postgresql_password: base64 encrypted password.
 
 
- This example is set to spin up a five node instance of 3 primaries and 2 secondaries, but the `primary_count` and `secondary_count` can be updated to build a larger or smaller cluster. The number of primaries should not go below 3, however.  
+ This example is set to spin up a five node instance of 3 primaries and 2 secondaries, but the `primary_count` and `secondary_count` can be updated to build a larger or smaller cluster. The number of primaries should not go below 3, however.
 
 ## Run Terraform
 
@@ -64,7 +64,7 @@ terraform apply
 
 ## Wait for the application to load
 
-The replicated console url will output along with the password.
+The install dashboard URL will output along with the password.
 
 ![output](https://github.com/hashicorp/terraform-google-terraform-enterprise/blob/master/examples/root-example/output_example.png?raw=true)
 

--- a/examples/root-example/README.md
+++ b/examples/root-example/README.md
@@ -54,7 +54,7 @@ terraform apply
 
 ## Wait for the application to load
 
-The replicated console url will output along with the password.
+The install dashboard URL will output along with the password.
 
 ![output](https://github.com/hashicorp/terraform-google-terraform-enterprise/blob/master/examples/root-example/output_example.png?raw=true)
 

--- a/examples/root-example/main.tf
+++ b/examples/root-example/main.tf
@@ -1,5 +1,5 @@
 provider "google" {
-  version = "3.1.0"
+  version = "3.2.0"
 }
 
 provider "google-beta" {

--- a/examples/shared-vpc/README.md
+++ b/examples/shared-vpc/README.md
@@ -100,7 +100,7 @@ GOOGLE_PROJECT="$HOST_PROJECT" terraform apply \
 -target module.host
 
 # Create the compute resources.
-GOOGLE_PROJECT="$SERVICE_PROJeCT" terraform apply \
+GOOGLE_PROJECT="$SERVICE_PROJECT" terraform apply \
 -target module.service
 
 # Obtain the outputs necessary to access the TFE Clustered deployment.

--- a/examples/shared-vpc/docs/outputs.md
+++ b/examples/shared-vpc/docs/outputs.md
@@ -5,6 +5,6 @@
 | Name | Description |
 |------|-------------|
 | application\_url | The URL of the application. |
-| console\_password | The generated password for the management console. |
-| console\_url | The URL of the management console. |
+| install\_dashboard\_password | The generated password for the install dashboard. |
+| install\_dashboard\_url | The URL of the install dashboard. |
 

--- a/examples/shared-vpc/main.tf
+++ b/examples/shared-vpc/main.tf
@@ -40,12 +40,12 @@ module "service" {
   vpc_cluster_assistant_tcp_port               = module.host.vpc.cluster_assistant_tcp_port
   vpc_etcd_tcp_port_ranges                     = module.host.vpc.etcd_tcp_port_ranges
   vpc_external_load_balancer_address           = module.host.vpc.external_load_balancer_address.address
+  vpc_install_dashboard_tcp_port               = module.host.vpc.install_dashboard_tcp_port
   vpc_kubelet_tcp_port                         = module.host.vpc.kubelet_tcp_port
   vpc_kubernetes_tcp_port                      = module.host.vpc.kubernetes_tcp_port
   vpc_network_self_link                        = module.host.vpc.network.self_link
   vpc_postgresql_address_name                  = module.host.vpc.postgresql_address.name
   vpc_replicated_tcp_port_ranges               = module.host.vpc.replicated_tcp_port_ranges
-  vpc_replicated_ui_tcp_port                   = module.host.vpc.replicated_ui_tcp_port
   vpc_ssh_tcp_port                             = module.host.vpc.ssh_tcp_port
   vpc_subnetwork_ip_cidr_range                 = module.host.vpc.subnetwork.ip_cidr_range
   vpc_subnetwork_name                          = module.host.vpc.subnetwork.name

--- a/examples/shared-vpc/modules/service/main.tf
+++ b/examples/shared-vpc/modules/service/main.tf
@@ -41,6 +41,7 @@ module "cloud_init" {
   internal_load_balancer_in_address = module.internal_load_balancer.in_address.address
   license_file                      = var.cloud_init_license_file
   vpc_cluster_assistant_tcp_port    = var.vpc_cluster_assistant_tcp_port
+  vpc_install_dashboard_tcp_port    = var.vpc_install_dashboard_tcp_port
   vpc_kubernetes_tcp_port           = var.vpc_kubernetes_tcp_port
 }
 
@@ -48,15 +49,15 @@ module "cloud_init" {
 module "primaries" {
   source = "hashicorp/terraform-enterprise/google//modules/primaries"
 
-  cloud_init_configs         = module.cloud_init.primaries_configs
-  prefix                     = var.prefix
-  service_account_email      = var.service_account_primaries_email
-  vpc_application_tcp_port   = var.vpc_application_tcp_port
-  vpc_kubernetes_tcp_port    = var.vpc_kubernetes_tcp_port
-  vpc_network_self_link      = var.vpc_network_self_link
-  vpc_replicated_ui_tcp_port = var.vpc_replicated_ui_tcp_port
-  vpc_subnetwork_project     = var.vpc_subnetwork_project
-  vpc_subnetwork_self_link   = var.vpc_subnetwork_self_link
+  cloud_init_configs             = module.cloud_init.primaries_configs
+  prefix                         = var.prefix
+  service_account_email          = var.service_account_primaries_email
+  vpc_application_tcp_port       = var.vpc_application_tcp_port
+  vpc_install_dashboard_tcp_port = var.vpc_install_dashboard_tcp_port
+  vpc_kubernetes_tcp_port        = var.vpc_kubernetes_tcp_port
+  vpc_network_self_link          = var.vpc_network_self_link
+  vpc_subnetwork_project         = var.vpc_subnetwork_project
+  vpc_subnetwork_self_link       = var.vpc_subnetwork_self_link
 
   labels = var.labels
 }
@@ -82,15 +83,15 @@ module "internal_load_balancer" {
 module "secondaries" {
   source = "hashicorp/terraform-enterprise/google//modules/secondaries"
 
-  cloud_init_config          = module.cloud_init.secondaries_config
-  prefix                     = var.prefix
-  service_account_email      = var.service_account_secondaries_email
-  vpc_application_tcp_port   = var.vpc_application_tcp_port
-  vpc_kubernetes_tcp_port    = var.vpc_kubernetes_tcp_port
-  vpc_network_self_link      = var.vpc_network_self_link
-  vpc_replicated_ui_tcp_port = var.vpc_replicated_ui_tcp_port
-  vpc_subnetwork_project     = var.vpc_subnetwork_project
-  vpc_subnetwork_self_link   = var.vpc_subnetwork_self_link
+  cloud_init_config              = module.cloud_init.secondaries_config
+  prefix                         = var.prefix
+  service_account_email          = var.service_account_secondaries_email
+  vpc_application_tcp_port       = var.vpc_application_tcp_port
+  vpc_kubernetes_tcp_port        = var.vpc_kubernetes_tcp_port
+  vpc_network_self_link          = var.vpc_network_self_link
+  vpc_install_dashboard_tcp_port = var.vpc_install_dashboard_tcp_port
+  vpc_subnetwork_project         = var.vpc_subnetwork_project
+  vpc_subnetwork_self_link       = var.vpc_subnetwork_self_link
 
   labels = var.labels
 }
@@ -106,6 +107,7 @@ module "external_load_balancer" {
   ssl_policy_self_link                              = module.ssl.policy.self_link
   vpc_address                                       = var.vpc_external_load_balancer_address
   vpc_application_tcp_port                          = var.vpc_application_tcp_port
+  vpc_install_dashboard_tcp_port                    = var.vpc_install_dashboard_tcp_port
 }
 
 # Configures DNS entries for the load balancer.

--- a/examples/shared-vpc/modules/service/variables.tf
+++ b/examples/shared-vpc/modules/service/variables.tf
@@ -67,6 +67,11 @@ variable "vpc_external_load_balancer_address" {
   type = string
 }
 
+variable "vpc_install_dashboard_tcp_port" {
+  description = "The install dashboard TCP port."
+  type        = string
+}
+
 variable "vpc_kubernetes_tcp_port" {
   description = "The Kubernetes TCP port."
   type        = string
@@ -89,11 +94,6 @@ variable "vpc_postgresql_address_name" {
 variable "vpc_replicated_tcp_port_ranges" {
   description = "The Replicated TCP port ranges."
   type        = list(string)
-}
-
-variable "vpc_replicated_ui_tcp_port" {
-  description = "The Replicated UI TCP port."
-  type        = string
 }
 
 variable "vpc_ssh_tcp_port" {

--- a/examples/shared-vpc/outputs.tf
+++ b/examples/shared-vpc/outputs.tf
@@ -1,17 +1,17 @@
 output "application_url" {
-  value = module.service.dns.application_url
+  value = "https://${module.service.dns.fqdn}/"
 
   description = "The URL of the application."
 }
 
-output "console_password" {
-  value = module.service.cloud_init.console_password
+output "install_dashboard_password" {
+  value = module.service.cloud_init.install_dashboard_password
 
-  description = "The generated password for the management console."
+  description = "The generated password for the install dashboard."
 }
 
-output "console_url" {
-  value = module.service.primaries.console_url
+output "install_dashboard_url" {
+  value = "https://${module.service.dns.fqdn}:${module.host.vpc.install_dashboard_tcp_port}/"
 
-  description = "The URL of the management console."
+  description = "The URL of the install dashboard."
 }

--- a/main.tf
+++ b/main.tf
@@ -58,6 +58,7 @@ module "cloud_init" {
   internal_load_balancer_in_address = module.internal_load_balancer.in_address.address
   license_file                      = var.cloud_init_license_file
   vpc_cluster_assistant_tcp_port    = module.vpc.cluster_assistant_tcp_port
+  vpc_install_dashboard_tcp_port    = module.vpc.install_dashboard_tcp_port
   vpc_kubernetes_tcp_port           = module.vpc.kubernetes_tcp_port
 }
 
@@ -116,7 +117,6 @@ module "secondaries" {
 module "external_load_balancer" {
   source = "./modules/external-load-balancer"
 
-  dns_fqdn                                          = module.dns.fqdn
   prefix                                            = var.prefix
   primaries_instance_group_self_link                = module.primaries.instance_group.self_link
   secondaries_instance_group_manager_instance_group = module.secondaries.instance_group_manager.instance_group

--- a/main.tf
+++ b/main.tf
@@ -116,6 +116,7 @@ module "secondaries" {
 module "external_load_balancer" {
   source = "./modules/external-load-balancer"
 
+  dns_fqdn                                          = module.dns.fqdn
   prefix                                            = var.prefix
   primaries_instance_group_self_link                = module.primaries.instance_group.self_link
   secondaries_instance_group_manager_instance_group = module.secondaries.instance_group_manager.instance_group
@@ -123,6 +124,7 @@ module "external_load_balancer" {
   ssl_policy_self_link                              = module.ssl.policy.self_link
   vpc_address                                       = module.vpc.external_load_balancer_address.address
   vpc_application_tcp_port                          = module.vpc.application_tcp_port
+  vpc_replicated_ui_tcp_port                        = module.vpc.replicated_ui_tcp_port
 }
 
 # Configures DNS entries for the load balancer.

--- a/main.tf
+++ b/main.tf
@@ -65,15 +65,15 @@ module "cloud_init" {
 module "primaries" {
   source = "./modules/primaries"
 
-  cloud_init_configs         = module.cloud_init.primaries_configs
-  prefix                     = var.prefix
-  service_account_email      = module.service_account.primaries.email
-  vpc_application_tcp_port   = module.vpc.application_tcp_port
-  vpc_kubernetes_tcp_port    = module.vpc.kubernetes_tcp_port
-  vpc_network_self_link      = module.vpc.network.self_link
-  vpc_replicated_ui_tcp_port = module.vpc.replicated_ui_tcp_port
-  vpc_subnetwork_project     = module.vpc.subnetwork.project
-  vpc_subnetwork_self_link   = module.vpc.subnetwork.self_link
+  cloud_init_configs             = module.cloud_init.primaries_configs
+  prefix                         = var.prefix
+  service_account_email          = module.service_account.primaries.email
+  vpc_application_tcp_port       = module.vpc.application_tcp_port
+  vpc_install_dashboard_tcp_port = module.vpc.install_dashboard_tcp_port
+  vpc_kubernetes_tcp_port        = module.vpc.kubernetes_tcp_port
+  vpc_network_self_link          = module.vpc.network.self_link
+  vpc_subnetwork_project         = module.vpc.subnetwork.project
+  vpc_subnetwork_self_link       = module.vpc.subnetwork.self_link
 
   labels = var.labels
 }
@@ -99,15 +99,15 @@ module "internal_load_balancer" {
 module "secondaries" {
   source = "./modules/secondaries"
 
-  cloud_init_config          = module.cloud_init.secondaries_config
-  prefix                     = var.prefix
-  service_account_email      = module.service_account.secondaries.email
-  vpc_application_tcp_port   = module.vpc.application_tcp_port
-  vpc_kubernetes_tcp_port    = module.vpc.kubernetes_tcp_port
-  vpc_network_self_link      = module.vpc.network.self_link
-  vpc_replicated_ui_tcp_port = module.vpc.replicated_ui_tcp_port
-  vpc_subnetwork_project     = module.vpc.subnetwork.project
-  vpc_subnetwork_self_link   = module.vpc.subnetwork.self_link
+  cloud_init_config              = module.cloud_init.secondaries_config
+  prefix                         = var.prefix
+  service_account_email          = module.service_account.secondaries.email
+  vpc_application_tcp_port       = module.vpc.application_tcp_port
+  vpc_install_dashboard_tcp_port = module.vpc.install_dashboard_tcp_port
+  vpc_kubernetes_tcp_port        = module.vpc.kubernetes_tcp_port
+  vpc_network_self_link          = module.vpc.network.self_link
+  vpc_subnetwork_project         = module.vpc.subnetwork.project
+  vpc_subnetwork_self_link       = module.vpc.subnetwork.self_link
 
   labels = var.labels
 }
@@ -124,7 +124,7 @@ module "external_load_balancer" {
   ssl_policy_self_link                              = module.ssl.policy.self_link
   vpc_address                                       = module.vpc.external_load_balancer_address.address
   vpc_application_tcp_port                          = module.vpc.application_tcp_port
-  vpc_replicated_ui_tcp_port                        = module.vpc.replicated_ui_tcp_port
+  vpc_install_dashboard_tcp_port                    = module.vpc.install_dashboard_tcp_port
 }
 
 # Configures DNS entries for the load balancer.

--- a/modules/cloud-init/docs/inputs.md
+++ b/modules/cloud-init/docs/inputs.md
@@ -7,8 +7,8 @@
 | application\_config | The application configuration. | `map(map(string))` | n/a | yes |
 | internal\_load\_balancer\_in\_address | The address assigned to the internal load balancer for traffic ingress. | `string` | n/a | yes |
 | license\_file | The pathname of a Replicated license file for the application. | `string` | n/a | yes |
-| vpc\_cluster\_assistant\_tcp\_port | The port over which Cluster Assistant TCP traffic will travel. | `string` | n/a | yes |
-| vpc\_kubernetes\_tcp\_port | The port over which Kubernetes TCP traffic will travel. | `string` | n/a | yes |
+| vpc\_cluster\_assistant\_tcp\_port | The Cluster Assistant TCP port. | `string` | n/a | yes |
+| vpc\_kubernetes\_tcp\_port | The Kubernetes TCP port. | `string` | n/a | yes |
 | additional\_no\_proxy | A list of hostnames to which traffic from the application will not be proxied. | `list(string)` | `[]` | no |
 | airgap\_installer\_url | The URL of an airgap package which contains the cluster installer. | `string` | `"https://install.terraform.io/installer/replicated-v5.tar.gz"` | no |
 | airgap\_package\_url | The URL of an airgap package which contains a TFE release. | `string` | `""` | no |

--- a/modules/cloud-init/docs/inputs.md
+++ b/modules/cloud-init/docs/inputs.md
@@ -9,6 +9,7 @@
 | license\_file | The pathname of a Replicated license file for the application. | `string` | n/a | yes |
 | vpc\_cluster\_assistant\_tcp\_port | The port over which Cluster Assistant TCP traffic will travel. | `string` | n/a | yes |
 | vpc\_kubernetes\_tcp\_port | The port over which Kubernetes TCP traffic will travel. | `string` | n/a | yes |
+| additional\_no\_proxy | A list of hostnames to which traffic from the application will not be proxied. | `list(string)` | `[]` | no |
 | airgap\_installer\_url | The URL of an airgap package which contains the cluster installer. | `string` | `"https://install.terraform.io/installer/replicated-v5.tar.gz"` | no |
 | airgap\_package\_url | The URL of an airgap package which contains a TFE release. | `string` | `""` | no |
 | custom\_ca\_cert\_url | The URL of a certificate authority bundle which contains custom certificates to be trusted by the application. | `string` | `""` | no |

--- a/modules/cloud-init/docs/inputs.md
+++ b/modules/cloud-init/docs/inputs.md
@@ -8,6 +8,7 @@
 | internal\_load\_balancer\_in\_address | The address assigned to the internal load balancer for traffic ingress. | `string` | n/a | yes |
 | license\_file | The pathname of a Replicated license file for the application. | `string` | n/a | yes |
 | vpc\_cluster\_assistant\_tcp\_port | The Cluster Assistant TCP port. | `string` | n/a | yes |
+| vpc\_install\_dashboard\_tcp\_port | The install dashboard TCP port. | `string` | n/a | yes |
 | vpc\_kubernetes\_tcp\_port | The Kubernetes TCP port. | `string` | n/a | yes |
 | additional\_no\_proxy | A list of hostnames to which traffic from the application will not be proxied. | `list(string)` | `[]` | no |
 | airgap\_installer\_url | The URL of an airgap package which contains the cluster installer. | `string` | `"https://install.terraform.io/installer/replicated-v5.tar.gz"` | no |

--- a/modules/cloud-init/docs/outputs.md
+++ b/modules/cloud-init/docs/outputs.md
@@ -4,7 +4,7 @@
 
 | Name | Description |
 |------|-------------|
-| console\_password | The generated password for the management console. |
+| install\_dashboard\_password | The generated password for the install dashboard. |
 | primaries\_configs | The list of cloud-init configurations to apply to the primaries. |
 | secondaries\_config | The cloud-init configuration to apply to the secondaries. |
 

--- a/modules/cloud-init/files/install-ptfe.sh
+++ b/modules/cloud-init/files/install-ptfe.sh
@@ -152,6 +152,13 @@ if [ "x${role}x" == "xmainx" ]; then
       )
     fi
 
+    if test -e /etc/ptfe/ui-bind-port; then
+      ui_bind_port="$(cat /etc/ptfe/ui-bind-port)"
+      ptfe_install_args+=(
+        --ui-bind-port "$ui_bind_port"
+      )
+    fi
+
     # ------------------------------------------------------------------------------
     # Custom CA certificate download and configuration block
     # ------------------------------------------------------------------------------

--- a/modules/cloud-init/main.tf
+++ b/modules/cloud-init/main.tf
@@ -39,6 +39,7 @@ locals {
         )
         replicated_rli       = var.license_file
         replicated_ptfe_conf = jsonencode(var.application_config)
+        ui_bind_port         = var.vpc_install_dashboard_tcp_port
         weave_cidr           = var.weave_cidr
       }
     ),

--- a/modules/cloud-init/main.tf
+++ b/modules/cloud-init/main.tf
@@ -32,7 +32,7 @@ locals {
           "${path.module}/templates/replicated.conf.tmpl",
           {
             airgap           = var.airgap_package_url != ""
-            console_password = random_pet.console_password.id
+            password         = random_pet.install_dashboard_password.id
             proxy_url        = var.proxy_url
             release_sequence = var.release_sequence
           }
@@ -86,7 +86,7 @@ locals {
   )
 }
 
-resource "random_pet" "console_password" {
+resource "random_pet" "install_dashboard_password" {
   length = 3
 }
 

--- a/modules/cloud-init/outputs.tf
+++ b/modules/cloud-init/outputs.tf
@@ -1,7 +1,7 @@
-output "console_password" {
-  value = random_pet.console_password.id
+output "install_dashboard_password" {
+  value = random_pet.install_dashboard_password.id
 
-  description = "The generated password for the management console."
+  description = "The generated password for the install dashboard."
 }
 
 output "primaries_configs" {

--- a/modules/cloud-init/templates/main-cloud-config.yaml.tmpl
+++ b/modules/cloud-init/templates/main-cloud-config.yaml.tmpl
@@ -46,6 +46,12 @@ ${primary_cloud_config}
   encoding: b64
   content: ${base64encode(repl_cidr)}
 %{ endif ~}
+
+- path: /etc/ptfe/ui-bind-port
+  owner: root:root
+  permissions: "0644"
+  encoding: b64
+  content: ${base64encode(ui_bind_port)}
 %{ if weave_cidr != "" ~}
 
 - path: /etc/ptfe/weave-cidr

--- a/modules/cloud-init/templates/replicated.conf.tmpl
+++ b/modules/cloud-init/templates/replicated.conf.tmpl
@@ -7,7 +7,7 @@
     "LicenseBootstrapAirgapPackagePath": "/var/lib/ptfe/ptfe.airgap",
 %{ endif ~}
     "DaemonAuthenticationType":          "password",
-    "DaemonAuthenticationPassword":      "${console_password}",
+    "DaemonAuthenticationPassword":      "${password}",
     "TlsBootstrapType":                  "self-signed",
     "BypassPreflightChecks":             true,
     "ImportSettingsFrom":                "/etc/replicated-ptfe.conf",

--- a/modules/cloud-init/variables.tf
+++ b/modules/cloud-init/variables.tf
@@ -74,12 +74,12 @@ variable "ssh_import_id_usernames" {
 }
 
 variable "vpc_cluster_assistant_tcp_port" {
-  description = "The port over which Cluster Assistant TCP traffic will travel."
+  description = "The Cluster Assistant TCP port."
   type        = string
 }
 
 variable "vpc_kubernetes_tcp_port" {
-  description = "The port over which Kubernetes TCP traffic will travel."
+  description = "The Kubernetes TCP port."
   type        = string
 }
 

--- a/modules/cloud-init/variables.tf
+++ b/modules/cloud-init/variables.tf
@@ -78,6 +78,11 @@ variable "vpc_cluster_assistant_tcp_port" {
   type        = string
 }
 
+variable "vpc_install_dashboard_tcp_port" {
+  description = "The install dashboard TCP port."
+  type        = string
+}
+
 variable "vpc_kubernetes_tcp_port" {
   description = "The Kubernetes TCP port."
   type        = string

--- a/modules/dns/docs/outputs.md
+++ b/modules/dns/docs/outputs.md
@@ -4,7 +4,5 @@
 
 | Name | Description |
 |------|-------------|
-| application\_url | The URL of the application. |
 | fqdn | The fully qualified domain name of the application. |
-| install\_dashboard\_url | The URL of the install dashboard. |
 

--- a/modules/dns/docs/outputs.md
+++ b/modules/dns/docs/outputs.md
@@ -6,4 +6,5 @@
 |------|-------------|
 | application\_url | The URL of the application. |
 | fqdn | The fully qualified domain name of the application. |
+| install\_dashboard\_url | The URL of the install dashboard. |
 

--- a/modules/dns/main.tf
+++ b/modules/dns/main.tf
@@ -1,4 +1,5 @@
 locals {
+  application_url = "https://${local.fqdn}"
   fqdn            = trimsuffix(local.record_set_name, ".")
   record_set_name = "${var.hostname}.${var.managed_zone_dns_name}"
 }

--- a/modules/dns/main.tf
+++ b/modules/dns/main.tf
@@ -1,5 +1,4 @@
 locals {
-  application_url = "https://${local.fqdn}"
   fqdn            = trimsuffix(local.record_set_name, ".")
   record_set_name = "${var.hostname}.${var.managed_zone_dns_name}"
 }

--- a/modules/dns/outputs.tf
+++ b/modules/dns/outputs.tf
@@ -1,17 +1,5 @@
-output "application_url" {
-  value = local.application_url
-
-  description = "The URL of the application."
-}
-
 output "fqdn" {
   value = local.fqdn
 
   description = "The fully qualified domain name of the application."
-}
-
-output "install_dashboard_url" {
-  value = "${local.application_url}/dashboard"
-
-  description = "The URL of the install dashboard."
 }

--- a/modules/dns/outputs.tf
+++ b/modules/dns/outputs.tf
@@ -1,5 +1,5 @@
 output "application_url" {
-  value = "https://${local.fqdn}"
+  value = local.application_url
 
   description = "The URL of the application."
 }
@@ -8,4 +8,10 @@ output "fqdn" {
   value = local.fqdn
 
   description = "The fully qualified domain name of the application."
+}
+
+output "install_dashboard_url" {
+  value = "${local.application_url}/dashboard"
+
+  description = "The URL of the install dashboard."
 }

--- a/modules/external-load-balancer/docs/inputs.md
+++ b/modules/external-load-balancer/docs/inputs.md
@@ -4,11 +4,13 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:-----:|
+| dns\_fqdn | The routable hostname of the application endpoint. | `string` | n/a | yes |
 | prefix | The prefix which will be prepended to the names of resources. | `string` | n/a | yes |
 | primaries\_instance\_group\_self\_link | The self link of the compute instance group for the primaries. | `string` | n/a | yes |
 | secondaries\_instance\_group\_manager\_instance\_group | The compute instance group of the secondaries. | `string` | n/a | yes |
 | ssl\_certificate\_self\_link | The self link of the managed SSL certificate which will be applied to the load balancer. | `string` | n/a | yes |
 | ssl\_policy\_self\_link | The self link of a compute SSL policy for the SSL certificate. | `string` | n/a | yes |
 | vpc\_address | The address which will be assigned to the load balancer. | `string` | n/a | yes |
-| vpc\_application\_tcp\_port | The port over which application TCP traffic will travel. | `string` | n/a | yes |
+| vpc\_application\_tcp\_port | The application TCP port. | `string` | n/a | yes |
+| vpc\_replicated\_ui\_tcp\_port | The Replicated UI TCP port. | `string` | n/a | yes |
 

--- a/modules/external-load-balancer/docs/inputs.md
+++ b/modules/external-load-balancer/docs/inputs.md
@@ -4,7 +4,6 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:-----:|
-| dns\_fqdn | The routable hostname of the application endpoint. | `string` | n/a | yes |
 | prefix | The prefix which will be prepended to the names of resources. | `string` | n/a | yes |
 | primaries\_instance\_group\_self\_link | The self link of the compute instance group for the primaries. | `string` | n/a | yes |
 | secondaries\_instance\_group\_manager\_instance\_group | The compute instance group of the secondaries. | `string` | n/a | yes |

--- a/modules/external-load-balancer/docs/inputs.md
+++ b/modules/external-load-balancer/docs/inputs.md
@@ -12,5 +12,5 @@
 | ssl\_policy\_self\_link | The self link of a compute SSL policy for the SSL certificate. | `string` | n/a | yes |
 | vpc\_address | The address which will be assigned to the load balancer. | `string` | n/a | yes |
 | vpc\_application\_tcp\_port | The application TCP port. | `string` | n/a | yes |
-| vpc\_replicated\_ui\_tcp\_port | The Replicated UI TCP port. | `string` | n/a | yes |
+| vpc\_install\_dashboard\_tcp\_port | The install dashboard TCP port. | `string` | n/a | yes |
 

--- a/modules/external-load-balancer/docs/outputs.md
+++ b/modules/external-load-balancer/docs/outputs.md
@@ -2,7 +2,5 @@
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| application\_forwarding\_rule | The global forwarding rule for application traffic. |
+No output.
 

--- a/modules/external-load-balancer/main.tf
+++ b/modules/external-load-balancer/main.tf
@@ -33,17 +33,162 @@ resource "google_compute_backend_service" "application" {
   timeout_sec = 10
 }
 
-resource "google_compute_url_map" "application" {
-  name = "${var.prefix}application"
+resource "google_compute_health_check" "replicated_ui" {
+  name = "${var.prefix}replicated-ui"
 
+  check_interval_sec = 5
+  description        = "The TFE Replicated UI health check."
+  tcp_health_check {
+    port = var.vpc_replicated_ui_tcp_port
+  }
+  timeout_sec = 4
+}
+
+resource "google_compute_backend_service" "replicated_ui" {
+  health_checks = [google_compute_health_check.replicated_ui.self_link]
+  name          = "${var.prefix}replicated-ui"
+
+  backend {
+    group = var.primaries_instance_group_self_link
+
+    balancing_mode        = "RATE"
+    description           = "The TFE primaries."
+    max_rate_per_instance = 333
+  }
+  backend {
+    group = var.secondaries_instance_group_manager_instance_group
+
+    balancing_mode        = "RATE"
+    description           = "The TFE secondaries."
+    max_rate_per_instance = 333
+  }
+  port_name   = "replicated-ui"
+  protocol    = "HTTPS"
+  timeout_sec = 10
+}
+
+resource "google_compute_url_map" "main" {
   default_service = google_compute_backend_service.application.self_link
-  description     = "The TFE application URL map."
+  name            = "${var.prefix}all-requests"
+
+  description = "The URL map for all TFE requests."
+  host_rule {
+    hosts        = [var.dns_fqdn]
+    path_matcher = "allpaths"
+
+    description = "Match the fully-qualified domain name of TFE."
+  }
+  path_matcher {
+    default_service = google_compute_backend_service.application.self_link
+    name            = "allpaths"
+
+    description = "Redirect requests to the application or the install dashboard path."
+    # This rule covers paths which are unique to the install dashboard.
+    path_rule {
+      # FIXME: https://tfe.emp-gcp.ptfedev.com/api/v1/support returns 502
+      paths = [
+        "/api/v1",
+        "/api/v1/*",
+        "/auditlog",
+        "/auditlog/*",
+        "/authenticate",
+        "/authenticate/*",
+        "/ceph",
+        "/ceph/*",
+        "/cluster",
+        "/cluster/*",
+        "/console",
+        "/console/*",
+        "/dashboard",
+        "/dashboard/*",
+        "/license",
+        "/license/*",
+        "/premkit",
+        "/premkit/*",
+        "/releases",
+        "/releases/*",
+        "/settings",
+        "/settings/*",
+        "/support",
+        "/support/*",
+      ]
+
+      service = google_compute_backend_service.replicated_ui.self_link
+    }
+    # This rule covers install dashboard asset paths under /assets. /assets is also used by application so paths must
+    # be listed explicitly.
+    path_rule {
+      paths = [
+        "/assets/03f50a3a6f195be73370626cc2887118.woff",
+        "/assets/36c91049d46f93c801176f06abb4b7f0.woff2",
+        "/assets/448c34a56d699c29117adc64c43affeb.woff2",
+        "/assets/50145685042b4df07a1fd19957275b81.ttf",
+        "/assets/629a55a7e793da068dc580d184cc0e31.ttf",
+        "/assets/8e976923f9d9c249cf32e75191cf797a.woff",
+        "/assets/a410ef2b4a38aa95291d109020a0b723.woff",
+        "/assets/af7ae505a9eed503f8b8e6982036873e.woff2",
+        "/assets/auditlog.main.23a3afa649a44fbe9fdb.js",
+        "/assets/authenticate.main.23a3afa649a44fbe9fdb.js",
+        "/assets/b06871f281fee6b241d60582ae9369b9.ttf",
+        "/assets/brand.23a3afa649a44fbe9fdb.css",
+        "/assets/c2d24dfda8a924bb6109080139a75698.woff2",
+        "/assets/c7dcce084c445260a266f92db56f5517.ttf",
+        "/assets/cluster.main.23a3afa649a44fbe9fdb.js",
+        "/assets/commons.23a3afa649a44fbe9fdb.css",
+        "/assets/commons.23a3afa649a44fbe9fdb.js",
+        "/assets/consolesettings.23a3afa649a44fbe9fdb.css",
+        "/assets/consolesettings.main.23a3afa649a44fbe9fdb.js",
+        "/assets/dashboard.23a3afa649a44fbe9fdb.css",
+        "/assets/dashboard.main.23a3afa649a44fbe9fdb.js",
+        "/assets/e18bbf611f2a2e43afc071aa2f4e1512.ttf",
+        "/assets/ec4dad2ea1198fed8332457c7778e7f1.woff2",
+        "/assets/fa2772327f55d8198301fdb8bcfc8158.woff",
+        "/assets/fee66e712a8a08eef5805a46892932ad.woff",
+        "/assets/licenseview.main.23a3afa649a44fbe9fdb.js",
+        "/assets/releases.main.23a3afa649a44fbe9fdb.js",
+        "/assets/settings.23a3afa649a44fbe9fdb.css",
+        "/assets/settings.main.23a3afa649a44fbe9fdb.js",
+        "/assets/snapshots.main.23a3afa649a44fbe9fdb.js",
+        "/assets/support.main.23a3afa649a44fbe9fdb.js",
+      ]
+
+      service = google_compute_backend_service.replicated_ui.self_link
+    }
+  }
+  test {
+    host    = var.dns_fqdn
+    path    = "/session"
+    service = google_compute_backend_service.application.self_link
+
+    description = "Test requests for the application."
+  }
+  test {
+    host    = var.dns_fqdn
+    path    = "/dashboard"
+    service = google_compute_backend_service.replicated_ui.self_link
+
+    description = "Test requests for install dashboard."
+  }
+  test {
+    host    = var.dns_fqdn
+    path    = "/assets/v2-14b7235f2176953201e84392b70d49a4b39d27e51015a3d1a67b0b0d9b4a03f0.css"
+    service = google_compute_backend_service.application.self_link
+
+    description = "Test requests for application assets."
+  }
+  test {
+    host    = var.dns_fqdn
+    path    = "/assets/03f50a3a6f195be73370626cc2887118.woff"
+    service = google_compute_backend_service.replicated_ui.self_link
+
+    description = "Test requests for install dashboard assets."
+  }
 }
 
 resource "google_compute_target_https_proxy" "application" {
   name             = "${var.prefix}application"
   ssl_certificates = [var.ssl_certificate_self_link]
-  url_map          = google_compute_url_map.application.self_link
+  url_map          = google_compute_url_map.main.self_link
 
   description = "The target HTTPS proxy for TFE application traffic."
   ssl_policy  = var.ssl_policy_self_link

--- a/modules/external-load-balancer/main.tf
+++ b/modules/external-load-balancer/main.tf
@@ -51,19 +51,19 @@ resource "google_compute_backend_service" "install_dashboard" {
   backend {
     group = var.primaries_instance_group_self_link
 
-    balancing_mode        = "RATE"
-    description           = "The TFE primaries."
-    max_rate_per_instance = 333
+    balancing_mode               = "CONNECTION"
+    description                  = "The TFE primaries."
+    max_connections_per_instance = 10
   }
   backend {
     group = var.secondaries_instance_group_manager_instance_group
 
-    balancing_mode        = "RATE"
-    description           = "The TFE secondaries."
-    max_rate_per_instance = 333
+    balancing_mode               = "CONNECTION"
+    description                  = "The TFE secondaries."
+    max_connections_per_instance = 10
   }
   port_name   = "install-dashboard"
-  protocol    = "HTTPS"
+  protocol    = "TCP"
   timeout_sec = 10
 }
 
@@ -72,117 +72,6 @@ resource "google_compute_url_map" "main" {
   name            = "${var.prefix}all-requests"
 
   description = "The URL map for all TFE requests."
-  host_rule {
-    hosts        = [var.dns_fqdn]
-    path_matcher = "allpaths"
-
-    description = "Match the fully-qualified domain name of TFE."
-  }
-  path_matcher {
-    default_service = google_compute_backend_service.application.self_link
-    name            = "allpaths"
-
-    description = "Redirect requests to the application or the install dashboard path."
-    # This rule covers paths which are unique to the install dashboard.
-    path_rule {
-      # FIXME: https://tfe.emp-gcp.ptfedev.com/api/v1/support returns 502
-      paths = [
-        "/api/v1",
-        "/api/v1/*",
-        "/auditlog",
-        "/auditlog/*",
-        "/authenticate",
-        "/authenticate/*",
-        "/ceph",
-        "/ceph/*",
-        "/cluster",
-        "/cluster/*",
-        "/console",
-        "/console/*",
-        "/dashboard",
-        "/dashboard/*",
-        "/license",
-        "/license/*",
-        "/premkit",
-        "/premkit/*",
-        "/releases",
-        "/releases/*",
-        "/settings",
-        "/settings/*",
-        "/support",
-        "/support/*",
-      ]
-
-      service = google_compute_backend_service.install_dashboard.self_link
-    }
-    # This rule covers install dashboard asset paths under /assets. /assets is also used by application so paths must
-    # be listed explicitly.
-    path_rule {
-      paths = [
-        "/assets/03f50a3a6f195be73370626cc2887118.woff",
-        "/assets/36c91049d46f93c801176f06abb4b7f0.woff2",
-        "/assets/448c34a56d699c29117adc64c43affeb.woff2",
-        "/assets/50145685042b4df07a1fd19957275b81.ttf",
-        "/assets/629a55a7e793da068dc580d184cc0e31.ttf",
-        "/assets/8e976923f9d9c249cf32e75191cf797a.woff",
-        "/assets/a410ef2b4a38aa95291d109020a0b723.woff",
-        "/assets/af7ae505a9eed503f8b8e6982036873e.woff2",
-        "/assets/auditlog.main.23a3afa649a44fbe9fdb.js",
-        "/assets/authenticate.main.23a3afa649a44fbe9fdb.js",
-        "/assets/b06871f281fee6b241d60582ae9369b9.ttf",
-        "/assets/brand.23a3afa649a44fbe9fdb.css",
-        "/assets/c2d24dfda8a924bb6109080139a75698.woff2",
-        "/assets/c7dcce084c445260a266f92db56f5517.ttf",
-        "/assets/cluster.main.23a3afa649a44fbe9fdb.js",
-        "/assets/commons.23a3afa649a44fbe9fdb.css",
-        "/assets/commons.23a3afa649a44fbe9fdb.js",
-        "/assets/consolesettings.23a3afa649a44fbe9fdb.css",
-        "/assets/consolesettings.main.23a3afa649a44fbe9fdb.js",
-        "/assets/dashboard.23a3afa649a44fbe9fdb.css",
-        "/assets/dashboard.main.23a3afa649a44fbe9fdb.js",
-        "/assets/e18bbf611f2a2e43afc071aa2f4e1512.ttf",
-        "/assets/ec4dad2ea1198fed8332457c7778e7f1.woff2",
-        "/assets/fa2772327f55d8198301fdb8bcfc8158.woff",
-        "/assets/fee66e712a8a08eef5805a46892932ad.woff",
-        "/assets/licenseview.main.23a3afa649a44fbe9fdb.js",
-        "/assets/releases.main.23a3afa649a44fbe9fdb.js",
-        "/assets/settings.23a3afa649a44fbe9fdb.css",
-        "/assets/settings.main.23a3afa649a44fbe9fdb.js",
-        "/assets/snapshots.main.23a3afa649a44fbe9fdb.js",
-        "/assets/support.main.23a3afa649a44fbe9fdb.js",
-      ]
-
-      service = google_compute_backend_service.install_dashboard.self_link
-    }
-  }
-  test {
-    host    = var.dns_fqdn
-    path    = "/session"
-    service = google_compute_backend_service.application.self_link
-
-    description = "Test requests for the application."
-  }
-  test {
-    host    = var.dns_fqdn
-    path    = "/dashboard"
-    service = google_compute_backend_service.install_dashboard.self_link
-
-    description = "Test requests for install dashboard."
-  }
-  test {
-    host    = var.dns_fqdn
-    path    = "/assets/v2-14b7235f2176953201e84392b70d49a4b39d27e51015a3d1a67b0b0d9b4a03f0.css"
-    service = google_compute_backend_service.application.self_link
-
-    description = "Test requests for application assets."
-  }
-  test {
-    host    = var.dns_fqdn
-    path    = "/assets/03f50a3a6f195be73370626cc2887118.woff"
-    service = google_compute_backend_service.install_dashboard.self_link
-
-    description = "Test requests for install dashboard assets."
-  }
 }
 
 resource "google_compute_target_https_proxy" "application" {
@@ -203,4 +92,22 @@ resource "google_compute_global_forwarding_rule" "application" {
   ip_protocol           = "TCP"
   load_balancing_scheme = "EXTERNAL"
   port_range            = var.vpc_application_tcp_port
+}
+
+resource "google_compute_target_tcp_proxy" "install_dashboard" {
+  backend_service = google_compute_backend_service.install_dashboard.self_link
+  name            = "${var.prefix}install-dashboard"
+
+  description = "The target TCP proxy for TFE install dashboard traffic."
+}
+
+resource "google_compute_global_forwarding_rule" "install_dashboard" {
+  name   = "${var.prefix}install-dashboard"
+  target = google_compute_target_tcp_proxy.install_dashboard.self_link
+
+  description           = "The global forwarding rule for TFE install dashboard traffic."
+  ip_address            = var.vpc_address
+  ip_protocol           = "TCP"
+  load_balancing_scheme = "EXTERNAL"
+  port_range            = var.vpc_install_dashboard_tcp_port
 }

--- a/modules/external-load-balancer/main.tf
+++ b/modules/external-load-balancer/main.tf
@@ -33,20 +33,20 @@ resource "google_compute_backend_service" "application" {
   timeout_sec = 10
 }
 
-resource "google_compute_health_check" "replicated_ui" {
-  name = "${var.prefix}replicated-ui"
+resource "google_compute_health_check" "install_dashboard" {
+  name = "${var.prefix}install-dashboard"
 
   check_interval_sec = 5
-  description        = "The TFE Replicated UI health check."
+  description        = "The TFE install dashboard UI health check."
   tcp_health_check {
-    port = var.vpc_replicated_ui_tcp_port
+    port = var.vpc_install_dashboard_tcp_port
   }
   timeout_sec = 4
 }
 
-resource "google_compute_backend_service" "replicated_ui" {
-  health_checks = [google_compute_health_check.replicated_ui.self_link]
-  name          = "${var.prefix}replicated-ui"
+resource "google_compute_backend_service" "install_dashboard" {
+  health_checks = [google_compute_health_check.install_dashboard.self_link]
+  name          = "${var.prefix}install-dashboard"
 
   backend {
     group = var.primaries_instance_group_self_link
@@ -62,7 +62,7 @@ resource "google_compute_backend_service" "replicated_ui" {
     description           = "The TFE secondaries."
     max_rate_per_instance = 333
   }
-  port_name   = "replicated-ui"
+  port_name   = "install-dashboard"
   protocol    = "HTTPS"
   timeout_sec = 10
 }
@@ -113,7 +113,7 @@ resource "google_compute_url_map" "main" {
         "/support/*",
       ]
 
-      service = google_compute_backend_service.replicated_ui.self_link
+      service = google_compute_backend_service.install_dashboard.self_link
     }
     # This rule covers install dashboard asset paths under /assets. /assets is also used by application so paths must
     # be listed explicitly.
@@ -152,7 +152,7 @@ resource "google_compute_url_map" "main" {
         "/assets/support.main.23a3afa649a44fbe9fdb.js",
       ]
 
-      service = google_compute_backend_service.replicated_ui.self_link
+      service = google_compute_backend_service.install_dashboard.self_link
     }
   }
   test {
@@ -165,7 +165,7 @@ resource "google_compute_url_map" "main" {
   test {
     host    = var.dns_fqdn
     path    = "/dashboard"
-    service = google_compute_backend_service.replicated_ui.self_link
+    service = google_compute_backend_service.install_dashboard.self_link
 
     description = "Test requests for install dashboard."
   }
@@ -179,7 +179,7 @@ resource "google_compute_url_map" "main" {
   test {
     host    = var.dns_fqdn
     path    = "/assets/03f50a3a6f195be73370626cc2887118.woff"
-    service = google_compute_backend_service.replicated_ui.self_link
+    service = google_compute_backend_service.install_dashboard.self_link
 
     description = "Test requests for install dashboard assets."
   }

--- a/modules/external-load-balancer/outputs.tf
+++ b/modules/external-load-balancer/outputs.tf
@@ -1,5 +1,0 @@
-output "application_forwarding_rule" {
-  value = google_compute_global_forwarding_rule.application
-
-  description = "The global forwarding rule for application traffic."
-}

--- a/modules/external-load-balancer/variables.tf
+++ b/modules/external-load-balancer/variables.tf
@@ -1,3 +1,8 @@
+variable "dns_fqdn" {
+  description = "The routable hostname of the application endpoint."
+  type        = string
+}
+
 variable "prefix" {
   description = "The prefix which will be prepended to the names of resources."
   type        = string
@@ -29,6 +34,11 @@ variable "vpc_address" {
 }
 
 variable "vpc_application_tcp_port" {
-  description = "The port over which application TCP traffic will travel."
+  description = "The application TCP port."
+  type        = string
+}
+
+variable "vpc_replicated_ui_tcp_port" {
+  description = "The Replicated UI TCP port."
   type        = string
 }

--- a/modules/external-load-balancer/variables.tf
+++ b/modules/external-load-balancer/variables.tf
@@ -1,8 +1,3 @@
-variable "dns_fqdn" {
-  description = "The routable hostname of the application endpoint."
-  type        = string
-}
-
 variable "prefix" {
   description = "The prefix which will be prepended to the names of resources."
   type        = string

--- a/modules/external-load-balancer/variables.tf
+++ b/modules/external-load-balancer/variables.tf
@@ -38,7 +38,7 @@ variable "vpc_application_tcp_port" {
   type        = string
 }
 
-variable "vpc_replicated_ui_tcp_port" {
-  description = "The Replicated UI TCP port."
+variable "vpc_install_dashboard_tcp_port" {
+  description = "The install dashboard TCP port."
   type        = string
 }

--- a/modules/primaries/docs/inputs.md
+++ b/modules/primaries/docs/inputs.md
@@ -7,10 +7,10 @@
 | cloud\_init\_configs | The cloud-init configurations for the compute instances. | `list(string)` | n/a | yes |
 | prefix | The prefix which will be prepended to the names of resources. | `string` | n/a | yes |
 | service\_account\_email | The email address of the service account to be associated with the compute instances. | `string` | n/a | yes |
-| vpc\_application\_tcp\_port | The port over which application TCP traffic will travel. | `string` | n/a | yes |
-| vpc\_kubernetes\_tcp\_port | The port over which Kubernetes TCP traffic will travel. | `string` | n/a | yes |
+| vpc\_application\_tcp\_port | The application TCP port. | `string` | n/a | yes |
+| vpc\_install\_dashboard\_tcp\_port | The install dashboard TCP port. | `string` | n/a | yes |
+| vpc\_kubernetes\_tcp\_port | The Kubernetes TCP port. | `string` | n/a | yes |
 | vpc\_network\_self\_link | The self link of the network to which resources will be attached. | `string` | n/a | yes |
-| vpc\_replicated\_ui\_tcp\_port | The port over which Replicated UI TCP traffic will travel. | `string` | n/a | yes |
 | vpc\_subnetwork\_project | The ID of the project in which var.vpc\_subnetwork\_self\_link exists. | `string` | n/a | yes |
 | vpc\_subnetwork\_self\_link | The self link of the subnetwork to which resources will be attached. The subnetwork must be part of var.vpc\_network\_self\_link. | `string` | n/a | yes |
 | disk\_image | The image from which to initialize the compute instance disks. The supported images are: ubuntu-1604-lts; ubuntu-1804-lts; rhel-7. | `string` | `"ubuntu-1804-lts"` | no |

--- a/modules/primaries/docs/outputs.md
+++ b/modules/primaries/docs/outputs.md
@@ -4,7 +4,6 @@
 
 | Name | Description |
 |------|-------------|
-| console\_url | The URL of the management console. |
 | instance\_group | The compute instance group for the cluster. |
 | instances | The compute instances which comprise the cluster. |
 

--- a/modules/primaries/main.tf
+++ b/modules/primaries/main.tf
@@ -44,12 +44,12 @@ resource "google_compute_instance_group" "main" {
     port = var.vpc_application_tcp_port
   }
   named_port {
-    name = "kubernetes"
-    port = var.vpc_kubernetes_tcp_port
+    name = "install-dashboard"
+    port = var.vpc_install_dashboard_tcp_port
   }
   named_port {
-    name = "replicated-ui"
-    port = var.vpc_replicated_ui_tcp_port
+    name = "kubernetes"
+    port = var.vpc_kubernetes_tcp_port
   }
 
   depends_on = [google_compute_instance.main]

--- a/modules/primaries/main.tf
+++ b/modules/primaries/main.tf
@@ -18,10 +18,6 @@ resource "google_compute_instance" "main" {
   network_interface {
     subnetwork         = var.vpc_subnetwork_self_link
     subnetwork_project = var.vpc_subnetwork_project
-
-    access_config {
-      # An empty configuration implies a public IP address.
-    }
   }
 
   allow_stopping_for_update = true

--- a/modules/primaries/outputs.tf
+++ b/modules/primaries/outputs.tf
@@ -1,14 +1,3 @@
-output "console_url" {
-  # This conditional logic prevents an invalid index error when the value is evaluated after
-  # google_compute_instance.primary is destroyed. An example of this scenario is when a destroy process is resumed
-  # after recovering from an error.
-  value = length(google_compute_instance.main) > 0 ? (
-    "https://${google_compute_instance.main[0].network_interface[0].access_config[0].nat_ip}:${var.vpc_replicated_ui_tcp_port}"
-  ) : ""
-
-  description = "The URL of the management console."
-}
-
 output "instances" {
   value = google_compute_instance.main
 

--- a/modules/primaries/variables.tf
+++ b/modules/primaries/variables.tf
@@ -27,21 +27,6 @@ variable "machine_type" {
   type        = string
 }
 
-variable "vpc_application_tcp_port" {
-  description = "The port over which application TCP traffic will travel."
-  type        = string
-}
-
-variable "vpc_kubernetes_tcp_port" {
-  description = "The port over which Kubernetes TCP traffic will travel."
-  type        = string
-}
-
-variable "vpc_replicated_ui_tcp_port" {
-  description = "The port over which Replicated UI TCP traffic will travel."
-  type        = string
-}
-
 variable "prefix" {
   description = "The prefix which will be prepended to the names of resources."
   type        = string
@@ -50,6 +35,21 @@ variable "prefix" {
 variable "service_account_email" {
   type        = string
   description = "The email address of the service account to be associated with the compute instances."
+}
+
+variable "vpc_application_tcp_port" {
+  description = "The application TCP port."
+  type        = string
+}
+
+variable "vpc_install_dashboard_tcp_port" {
+  description = "The install dashboard TCP port."
+  type        = string
+}
+
+variable "vpc_kubernetes_tcp_port" {
+  description = "The Kubernetes TCP port."
+  type        = string
 }
 
 variable "vpc_network_self_link" {

--- a/modules/secondaries/docs/inputs.md
+++ b/modules/secondaries/docs/inputs.md
@@ -7,10 +7,10 @@
 | cloud\_init\_config | The cloud-init configuration for the compute instances. | `string` | n/a | yes |
 | prefix | The prefix which will be prepended to the names of resources. | `string` | n/a | yes |
 | service\_account\_email | The email address of the service account which will be associated with the secondaries. | `string` | n/a | yes |
-| vpc\_application\_tcp\_port | The port over which application TCP traffic will travel. | `string` | n/a | yes |
-| vpc\_kubernetes\_tcp\_port | The port over which Kubernetes TCP traffic will travel. | `string` | n/a | yes |
+| vpc\_application\_tcp\_port | The application TCP port. | `string` | n/a | yes |
+| vpc\_install\_dashboard\_tcp\_port | The install dashboard TCP port. | `string` | n/a | yes |
+| vpc\_kubernetes\_tcp\_port | The Kubernetes TCP port. | `string` | n/a | yes |
 | vpc\_network\_self\_link | The self link of the network to which resources will be attached. | `string` | n/a | yes |
-| vpc\_replicated\_ui\_tcp\_port | The port over which Replicated UI TCP traffic will travel. | `string` | n/a | yes |
 | vpc\_subnetwork\_project | The ID of the project in which var.vpc\_subnetwork\_self\_link exists. | `string` | n/a | yes |
 | vpc\_subnetwork\_self\_link | The self link of the subnetwork to which resources will be attached. The subnetwork must be part of var.vpc\_network\_self\_link. | `string` | n/a | yes |
 | cpu\_utilization\_target | The CPU utilization target of the compute instance group which will trigger the creation of an additional instance. | `number` | `0.7` | no |

--- a/modules/secondaries/main.tf
+++ b/modules/secondaries/main.tf
@@ -11,10 +11,6 @@ resource "google_compute_instance_template" "main" {
   network_interface {
     subnetwork         = var.vpc_subnetwork_self_link
     subnetwork_project = var.vpc_subnetwork_project
-
-    access_config {
-      # An empty configuration implies a public IP address.
-    }
   }
 
   can_ip_forward = true

--- a/modules/secondaries/main.tf
+++ b/modules/secondaries/main.tf
@@ -46,12 +46,12 @@ resource "google_compute_region_instance_group_manager" "main" {
     port = var.vpc_application_tcp_port
   }
   named_port {
-    name = "kubernetes"
-    port = var.vpc_kubernetes_tcp_port
+    name = "install-dashboard"
+    port = var.vpc_install_dashboard_tcp_port
   }
   named_port {
-    name = "replicated-ui"
-    port = var.vpc_replicated_ui_tcp_port
+    name = "kubernetes"
+    port = var.vpc_kubernetes_tcp_port
   }
 
   lifecycle {

--- a/modules/secondaries/variables.tf
+++ b/modules/secondaries/variables.tf
@@ -44,21 +44,6 @@ variable "min_instances" {
   type        = number
 }
 
-variable "vpc_application_tcp_port" {
-  description = "The port over which application TCP traffic will travel."
-  type        = string
-}
-
-variable "vpc_kubernetes_tcp_port" {
-  description = "The port over which Kubernetes TCP traffic will travel."
-  type        = string
-}
-
-variable "vpc_replicated_ui_tcp_port" {
-  description = "The port over which Replicated UI TCP traffic will travel."
-  type        = string
-}
-
 variable "prefix" {
   description = "The prefix which will be prepended to the names of resources."
   type        = string
@@ -67,6 +52,21 @@ variable "prefix" {
 variable "service_account_email" {
   type        = string
   description = "The email address of the service account which will be associated with the secondaries."
+}
+
+variable "vpc_application_tcp_port" {
+  description = "The application TCP port."
+  type        = string
+}
+
+variable "vpc_install_dashboard_tcp_port" {
+  description = "The install dashboard TCP port."
+  type        = string
+}
+
+variable "vpc_kubernetes_tcp_port" {
+  description = "The Kubernetes TCP port."
+  type        = string
 }
 
 variable "vpc_network_self_link" {

--- a/modules/vpc/docs/inputs.md
+++ b/modules/vpc/docs/inputs.md
@@ -8,11 +8,11 @@
 | service\_account\_internal\_load\_balancer\_email | The email address of the service account associated with the internal load balancer. | `string` | n/a | yes |
 | service\_account\_primaries\_email | The email address of the service account associated with the primaries. | `string` | n/a | yes |
 | service\_account\_secondaries\_email | The email address of the service account associated with the secondaries. | `string` | n/a | yes |
-| application\_tcp\_port | The Application TCP port. | `string` | `"443"` | no |
+| application\_tcp\_port | The Application TCP port. The value must be supported for HTTPS load balancing. More information is available at https://cloud.google.com/load-balancing/docs/https. | `string` | `"443"` | no |
 | cluster\_assistant\_tcp\_port | The Cluster Assistant TCP port. | `string` | `"23010"` | no |
 | etcd\_tcp\_port\_ranges | The etcd TCP port ranges. | `list(string)` | <pre>[<br>  "2379",<br>  "2380",<br>  "4001",<br>  "7001"<br>]</pre> | no |
 | health\_check\_ip\_cidr\_ranges | The list of GCP health check IP address ranges from which health check traffic will be authorized to flow, expressed in CIDR notation. The default ranges were obtained from the GCP Health Checks Overview: https://cloud.google.com/load-balancing/docs/health-check-concepts#ip-ranges. | `list(string)` | <pre>[<br>  "35.191.0.0/16",<br>  "130.211.0.0/22"<br>]</pre> | no |
-| install\_dashboard\_tcp\_port | The install dashboard TCP port. | `string` | `"8085"` | no |
+| install\_dashboard\_tcp\_port | The install dashboard TCP port. The value must be supported for TCP load balancing. More information is available at https://cloud.google.com/load-balancing/docs/tcp. | `string` | `"8085"` | no |
 | kubelet\_tcp\_port | The Kubelet TCP port. | `string` | `"10250"` | no |
 | kubernetes\_tcp\_port | The Kubernetes TCP port. | `string` | `"6443"` | no |
 | replicated\_tcp\_port\_ranges | The Replicated TCP port ranges. | `list(string)` | <pre>[<br>  "9870-9881"<br>]</pre> | no |

--- a/modules/vpc/docs/inputs.md
+++ b/modules/vpc/docs/inputs.md
@@ -12,10 +12,10 @@
 | cluster\_assistant\_tcp\_port | The Cluster Assistant TCP port. | `string` | `"23010"` | no |
 | etcd\_tcp\_port\_ranges | The etcd TCP port ranges. | `list(string)` | <pre>[<br>  "2379",<br>  "2380",<br>  "4001",<br>  "7001"<br>]</pre> | no |
 | health\_check\_ip\_cidr\_ranges | The list of GCP health check IP address ranges from which health check traffic will be authorized to flow, expressed in CIDR notation. The default ranges were obtained from the GCP Health Checks Overview: https://cloud.google.com/load-balancing/docs/health-check-concepts#ip-ranges. | `list(string)` | <pre>[<br>  "35.191.0.0/16",<br>  "130.211.0.0/22"<br>]</pre> | no |
+| install\_dashboard\_tcp\_port | The install dashboard TCP port. | `string` | `"8800"` | no |
 | kubelet\_tcp\_port | The Kubelet TCP port. | `string` | `"10250"` | no |
 | kubernetes\_tcp\_port | The Kubernetes TCP port. | `string` | `"6443"` | no |
 | replicated\_tcp\_port\_ranges | The Replicated TCP port ranges. | `list(string)` | <pre>[<br>  "9870-9881"<br>]</pre> | no |
-| replicated\_ui\_tcp\_port | The Replicated UI TCP port. | `string` | `"8800"` | no |
 | ssh\_tcp\_port | The SSH TCP port. | `string` | `"22"` | no |
 | subnetwork\_ip\_cidr\_range | The range of IP addresses to provision in the subnetwork, expressed in CIDR notation. | `string` | `"10.1.0.0/16"` | no |
 | weave\_tcp\_port | The Weave ports. | `string` | `"6783"` | no |

--- a/modules/vpc/docs/inputs.md
+++ b/modules/vpc/docs/inputs.md
@@ -12,7 +12,7 @@
 | cluster\_assistant\_tcp\_port | The Cluster Assistant TCP port. | `string` | `"23010"` | no |
 | etcd\_tcp\_port\_ranges | The etcd TCP port ranges. | `list(string)` | <pre>[<br>  "2379",<br>  "2380",<br>  "4001",<br>  "7001"<br>]</pre> | no |
 | health\_check\_ip\_cidr\_ranges | The list of GCP health check IP address ranges from which health check traffic will be authorized to flow, expressed in CIDR notation. The default ranges were obtained from the GCP Health Checks Overview: https://cloud.google.com/load-balancing/docs/health-check-concepts#ip-ranges. | `list(string)` | <pre>[<br>  "35.191.0.0/16",<br>  "130.211.0.0/22"<br>]</pre> | no |
-| install\_dashboard\_tcp\_port | The install dashboard TCP port. | `string` | `"8800"` | no |
+| install\_dashboard\_tcp\_port | The install dashboard TCP port. | `string` | `"8085"` | no |
 | kubelet\_tcp\_port | The Kubelet TCP port. | `string` | `"10250"` | no |
 | kubernetes\_tcp\_port | The Kubernetes TCP port. | `string` | `"6443"` | no |
 | replicated\_tcp\_port\_ranges | The Replicated TCP port ranges. | `list(string)` | <pre>[<br>  "9870-9881"<br>]</pre> | no |

--- a/modules/vpc/docs/outputs.md
+++ b/modules/vpc/docs/outputs.md
@@ -4,16 +4,16 @@
 
 | Name | Description |
 |------|-------------|
-| application\_tcp\_port | The Application TCP port. |
+| application\_tcp\_port | The application TCP port. |
 | cluster\_assistant\_tcp\_port | The Cluster Assistant TCP port. |
 | etcd\_tcp\_port\_ranges | The etcd TCP port ranges. |
 | external\_load\_balancer\_address | n/a |
+| install\_dashboard\_tcp\_port | The install dashboard TCP port. |
 | kubelet\_tcp\_port | The Kubelet TCP port. |
 | kubernetes\_tcp\_port | The Kubernetes TCP port. |
 | network | The network to which resources will be attached. |
 | postgresql\_address | n/a |
 | replicated\_tcp\_port\_ranges | The Replicated TCP port ranges. |
-| replicated\_ui\_tcp\_port | The Replicated UI TCP port. |
 | ssh\_tcp\_port | The SSH TCP port. |
 | subnetwork | The subnetwork to which resources will be attached. |
 | weave\_tcp\_port | The Weave ports. |

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -82,11 +82,6 @@ locals {
     var.service_account_secondaries_email
   ]
   internal_load_balancer_service_account = [var.service_account_internal_load_balancer_email]
-  ssh_ui_ports = [
-    var.application_tcp_port,
-    var.ssh_tcp_port,
-    var.replicated_ui_tcp_port
-  ]
 }
 
 resource "google_compute_firewall" "health_checks_application" {
@@ -128,7 +123,11 @@ resource "google_compute_firewall" "allow_all_ssh_ui" {
   allow {
     protocol = "tcp"
 
-    ports = local.ssh_ui_ports
+    ports = [
+      var.application_tcp_port,
+      var.install_dashboard_tcp_port,
+      var.ssh_tcp_port,
+    ]
   }
   description             = "Allow ingress of SSH and UI traffic from any source to the primaries and the secondaries."
   direction               = "INGRESS"

--- a/modules/vpc/outputs.tf
+++ b/modules/vpc/outputs.tf
@@ -1,7 +1,7 @@
 output "application_tcp_port" {
   value = var.application_tcp_port
 
-  description = "The Application TCP port."
+  description = "The application TCP port."
 }
 
 output "cluster_assistant_tcp_port" {
@@ -18,6 +18,12 @@ output "etcd_tcp_port_ranges" {
 
 output "external_load_balancer_address" {
   value = google_compute_global_address.external_load_balancer
+}
+
+output "install_dashboard_tcp_port" {
+  value = var.install_dashboard_tcp_port
+
+  description = "The install dashboard TCP port."
 }
 
 output "kubernetes_tcp_port" {
@@ -46,12 +52,6 @@ output "replicated_tcp_port_ranges" {
   value = var.replicated_tcp_port_ranges
 
   description = "The Replicated TCP port ranges."
-}
-
-output "replicated_ui_tcp_port" {
-  value = var.replicated_ui_tcp_port
-
-  description = "The Replicated UI TCP port."
 }
 
 output "ssh_tcp_port" {

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -1,6 +1,6 @@
 variable "application_tcp_port" {
   default     = "443"
-  description = "The Application TCP port."
+  description = "The Application TCP port. The value must be supported for HTTPS load balancing. More information is available at https://cloud.google.com/load-balancing/docs/https."
   type        = string
 }
 
@@ -23,7 +23,7 @@ variable "health_check_ip_cidr_ranges" {
 
 variable "install_dashboard_tcp_port" {
   default     = "8085"
-  description = "The install dashboard TCP port."
+  description = "The install dashboard TCP port. The value must be supported for TCP load balancing. More information is available at https://cloud.google.com/load-balancing/docs/tcp."
   type        = string
 }
 

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -21,6 +21,12 @@ variable "health_check_ip_cidr_ranges" {
   type        = list(string)
 }
 
+variable "install_dashboard_tcp_port" {
+  default     = "8800"
+  description = "The install dashboard TCP port."
+  type        = string
+}
+
 variable "kubernetes_tcp_port" {
   default     = "6443"
   description = "The Kubernetes TCP port."
@@ -42,12 +48,6 @@ variable "replicated_tcp_port_ranges" {
   default     = ["9870-9881"]
   description = "The Replicated TCP port ranges."
   type        = list(string)
-}
-
-variable "replicated_ui_tcp_port" {
-  default     = "8800"
-  description = "The Replicated UI TCP port."
-  type        = string
 }
 
 variable "ssh_tcp_port" {

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -22,7 +22,7 @@ variable "health_check_ip_cidr_ranges" {
 }
 
 variable "install_dashboard_tcp_port" {
-  default     = "8800"
+  default     = "8085"
   description = "The install dashboard TCP port."
   type        = string
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,5 @@
 output "application_url" {
-  value = module.dns.application_url
+  value = "https://${module.dns.fqdn}/"
 
   description = "The URL of the application."
 }
@@ -11,7 +11,7 @@ output "install_dashboard_password" {
 }
 
 output "install_dashboard_url" {
-  value = module.dns.install_dashboard_url
+  value = "https://${module.dns.fqdn}:${module.vpc.install_dashboard_tcp_port}/"
 
   description = "The URL of the install dashboard."
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,8 +4,14 @@ output "application_url" {
   description = "The URL of the application."
 }
 
-output "console_password" {
-  value = module.cloud_init.console_password
+output "install_dashboard_password" {
+  value = module.cloud_init.install_dashboard_password
 
-  description = "The generated password for the management console."
+  description = "The generated password for the install dashboard."
+}
+
+output "install_dashboard_url" {
+  value = module.dns.install_dashboard_url
+
+  description = "The URL of the install dashboard."
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,9 +9,3 @@ output "console_password" {
 
   description = "The generated password for the management console."
 }
-
-output "console_url" {
-  value = module.primaries.console_url
-
-  description = "The URL of the management console."
-}

--- a/versions.tf
+++ b/versions.tf
@@ -3,8 +3,8 @@ terraform {
   required_version = "~> 0.12.17"
 
   required_providers {
-    # 3.1.0 is the earliest version of google which supports google_compute_firewall enable_logging
-    google = "~> 3.1"
+    # 3.2.0 is the earliest version of google which supports google_compute_url_map path_rule
+    google = "~> 3.2"
     # 3 is the latest major release
     google-beta = "~> 3.0"
     # 2.1.0 is the earliest version of random and template which is compatible with Terraform 0.12


### PR DESCRIPTION
## Background

Users have requested that the cluster be deployed without public IP addresses assigned to each compute instance.

Removing the public IP addresses is a simple change as the VPC is configured to allow egress through the NAT router.

~The challenging part to these changes is load balancing requests to the install dashboard (formerly the Replicated UI). GCP only supports global load balancing of HTTPS over port 443, so this implementation uses URL mapping to redirect requests for install dashboard elements to the correct backend service. It remains to be seen how brittle this is.~

TCP load balancing is used for install dashboard requests in order to support HTTPS over a port other than 443.

Relates: #38 
Asana: [1](https://app.asana.com/0/1154290859794274/1162804246419705/f), [2](https://app.asana.com/0/1168960898522641/1164944574005921/f)

## How Has This Been Tested

I deployed a cluster using the root example with the source modified to reference the local root module. ~I clicked through the different paths of the install dashboard to ensure that all assets loaded successfully.~ I used a prereleased version of ptfe which supports `--ui-bind-port` and verified that the install dashboard came up on port 8085.

### Test Configuration

* Terraform Version: 0.12.17

## This PR makes me feel

![a private journal](https://media0.giphy.com/media/leqmpruKOh3gY/giphy.gif?cid=5a38a5a2ec608784627b47c7663cc13550d59be5229c45c4&rid=giphy.gif)
