### PR TITLE
Update proxy example based on Shared VPC changes

### DIFF
--- a/examples/proxy/main.tf
+++ b/examples/proxy/main.tf
@@ -19,34 +19,10 @@ module "storage" {
 module "vpc" {
   source = "hashicorp/terraform-enterprise/google//modules/vpc"
 
-  prefix = var.prefix
-}
-
-# Define the ports of the various services which make up the cluster.
-module "port" {
-  source = "hashicorp/terraform-enterprise/google//modules/port"
-}
-
-# Create firewalls to control network traffic.
-module "firewall" {
-  source = "hashicorp/terraform-enterprise/google//modules/firewall"
-
-  port_application_tcp                         = module.port.application_tcp
-  port_cluster_assistant_tcp                   = module.port.cluster_assistant_tcp
-  port_etcd_tcp_ranges                         = module.port.etcd_tcp_ranges
-  port_kubelet_tcp                             = module.port.kubelet_tcp
-  port_kubernetes_tcp                          = module.port.kubernetes_tcp
-  port_replicated_tcp_ranges                   = module.port.replicated_tcp_ranges
-  port_replicated_ui_tcp                       = module.port.replicated_ui_tcp
-  port_ssh_tcp                                 = module.port.ssh_tcp
-  port_weave_tcp                               = module.port.weave_tcp
-  port_weave_udp_ranges                        = module.port.weave_udp_ranges
   prefix                                       = var.prefix
-  service_account_primaries_email              = module.service_account.primaries.email
   service_account_internal_load_balancer_email = module.service_account.internal_load_balancer.email
+  service_account_primaries_email              = module.service_account.primaries.email
   service_account_secondaries_email            = module.service_account.secondaries.email
-  vpc_network_self_link                        = module.vpc.network.self_link
-  vpc_subnetwork_ip_cidr_range                 = module.vpc.subnetwork.ip_cidr_range
 }
 
 # Create a PostgreSQL database in which application data will be stored.
@@ -54,6 +30,7 @@ module "postgresql" {
   source = "hashicorp/terraform-enterprise/google//modules/postgresql"
 
   prefix                = var.prefix
+  vpc_address_name      = module.vpc.postgresql_address.name
   vpc_network_self_link = module.vpc.network.self_link
 
   labels = var.labels
@@ -91,27 +68,27 @@ module "proxy" {
 module "cloud_init" {
   source = "hashicorp/terraform-enterprise/google//modules/cloud-init"
 
-  application_config             = module.application.config
-  internal_load_balancer_address = module.internal_load_balancer.address.address
-  license_file                   = var.cloud_init_license_file
-  port_cluster_assistant_tcp     = module.port.cluster_assistant_tcp
-  port_kubernetes_tcp            = module.port.kubernetes_tcp
-  proxy_url                      = module.proxy.url
+  application_config                = module.application.config
+  internal_load_balancer_in_address = module.internal_load_balancer.in_address.address
+  license_file                      = var.cloud_init_license_file
+  vpc_cluster_assistant_tcp_port    = module.vpc.cluster_assistant_tcp_port
+  vpc_kubernetes_tcp_port           = module.vpc.kubernetes_tcp_port
+  proxy_url                         = module.proxy.url
 }
 
 # Create the primaries.
 module "primaries" {
   source = "hashicorp/terraform-enterprise/google//modules/primaries"
 
-  cloud_init_configs       = module.cloud_init.primaries_configs
-  port_application_tcp     = module.port.application_tcp
-  port_kubernetes_tcp      = module.port.kubernetes_tcp
-  port_replicated_ui_tcp   = module.port.replicated_ui_tcp
-  prefix                   = var.prefix
-  service_account_email    = module.service_account.primaries.email
-  vpc_network_self_link    = module.vpc.network.self_link
-  vpc_subnetwork_project   = module.vpc.subnetwork.project
-  vpc_subnetwork_self_link = module.vpc.subnetwork.self_link
+  cloud_init_configs         = module.cloud_init.primaries_configs
+  prefix                     = var.prefix
+  service_account_email      = module.service_account.primaries.email
+  vpc_application_tcp_port   = module.vpc.application_tcp_port
+  vpc_kubernetes_tcp_port    = module.vpc.kubernetes_tcp_port
+  vpc_network_self_link      = module.vpc.network.self_link
+  vpc_replicated_ui_tcp_port = module.vpc.replicated_ui_tcp_port
+  vpc_subnetwork_project     = module.vpc.subnetwork.project
+  vpc_subnetwork_self_link   = module.vpc.subnetwork.self_link
 
   labels = var.labels
 }
@@ -120,11 +97,11 @@ module "primaries" {
 module "internal_load_balancer" {
   source = "hashicorp/terraform-enterprise/google//modules/internal-load-balancer"
 
-  port_kubernetes_tcp                = module.port.kubernetes_tcp
-  port_cluster_assistant_tcp         = module.port.cluster_assistant_tcp
   prefix                             = var.prefix
   primaries_instance_group_self_link = module.primaries.instance_group.self_link
   service_account_email              = module.service_account.internal_load_balancer.email
+  vpc_cluster_assistant_tcp_port     = module.vpc.cluster_assistant_tcp_port
+  vpc_kubernetes_tcp_port            = module.vpc.kubernetes_tcp_port
   vpc_network_self_link              = module.vpc.network.self_link
   vpc_subnetwork_ip_cidr_range       = module.vpc.subnetwork.ip_cidr_range
   vpc_subnetwork_project             = module.vpc.subnetwork.project
@@ -137,15 +114,15 @@ module "internal_load_balancer" {
 module "secondaries" {
   source = "hashicorp/terraform-enterprise/google//modules/secondaries"
 
-  cloud_init_config        = module.cloud_init.secondaries_config
-  port_application_tcp     = module.port.application_tcp
-  port_kubernetes_tcp      = module.port.kubernetes_tcp
-  port_replicated_ui_tcp   = module.port.replicated_ui_tcp
-  prefix                   = var.prefix
-  service_account_email    = module.service_account.secondaries.email
-  vpc_network_self_link    = module.vpc.network.self_link
-  vpc_subnetwork_project   = module.vpc.subnetwork.project
-  vpc_subnetwork_self_link = module.vpc.subnetwork.self_link
+  cloud_init_config          = module.cloud_init.secondaries_config
+  prefix                     = var.prefix
+  service_account_email      = module.service_account.secondaries.email
+  vpc_application_tcp_port   = module.vpc.application_tcp_port
+  vpc_kubernetes_tcp_port    = module.vpc.kubernetes_tcp_port
+  vpc_network_self_link      = module.vpc.network.self_link
+  vpc_replicated_ui_tcp_port = module.vpc.replicated_ui_tcp_port
+  vpc_subnetwork_project     = module.vpc.subnetwork.project
+  vpc_subnetwork_self_link   = module.vpc.subnetwork.self_link
 
   labels = var.labels
 }
@@ -154,29 +131,22 @@ module "secondaries" {
 module "external_load_balancer" {
   source = "hashicorp/terraform-enterprise/google//modules/external-load-balancer"
 
-  global_address                                    = module.global.address.address
-  port_application_tcp                              = module.port.application_tcp
   prefix                                            = var.prefix
   primaries_instance_group_self_link                = module.primaries.instance_group.self_link
   secondaries_instance_group_manager_instance_group = module.secondaries.instance_group_manager.instance_group
   ssl_certificate_self_link                         = module.ssl.certificate.self_link
   ssl_policy_self_link                              = module.ssl.policy.self_link
+  vpc_address                                       = module.vpc.external_load_balancer_address.address
+  vpc_application_tcp_port                          = module.vpc.application_tcp_port
 }
 
 # Configures DNS entries for the load balancer.
 module "dns" {
   source = "hashicorp/terraform-enterprise/google//modules/dns"
 
-  global_address        = module.global.address.address
-  managed_zone          = var.dns_managed_zone
-  managed_zone_dns_name = var.dns_managed_zone_dns_name
-}
-
-# Create a global address to be attached to the external load balancer.
-module "global" {
-  source = "hashicorp/terraform-enterprise/google//modules/global"
-
-  prefix = var.prefix
+  managed_zone                       = var.dns_managed_zone
+  managed_zone_dns_name              = var.dns_managed_zone_dns_name
+  vpc_external_load_balancer_address = module.vpc.external_load_balancer_address.address
 }
 
 # Create an SSL certificate to be attached to the external load balancer.


### PR DESCRIPTION
## Background

The proxy example was not updated when the Shared VPC changes were merged. This branch updates the example.


Relates #38 


## How Has This Been Tested

I updated the module sources in the example to use local filesystem references and then followed the instructions in the README.

### Test Configuration

* Terraform Version: 0.12.24

## This PR makes me feel

![Realizing you forgot something](https://media2.giphy.com/media/pOD7xmRum8R6o/giphy.gif?cid=5a38a5a21f7978467fe44c024fe1f148d4642393abe7ae30&rid=giphy.gif)

