### PR TITLE
Update default PTFE URL

### DIFF
--- a/modules/cloud-init/docs/inputs.md
+++ b/modules/cloud-init/docs/inputs.md
@@ -16,7 +16,7 @@
 | custom\_ca\_cert\_url | The URL of a certificate authority bundle which contains custom certificates to be trusted by the application. | `string` | `""` | no |
 | distribution | The type of Linux distribution which will be running on the machines. | `string` | `"ubuntu"` | no |
 | proxy\_url | The URL of a proxy through which application traffic will be routed. | `string` | `""` | no |
-| ptfe\_url | The URL of the cluster installer tool. | `string` | `"https://install.terraform.io/installer/ptfe-0.1.zip"` | no |
+| ptfe\_url | The URL of the cluster installer tool. | `string` | `"https://install.terraform.io/installer/ptfe-stable.zip"` | no |
 | release\_sequence | The sequence identifier of the TFE version to which the cluster will be pinned. | `string` | `"latest"` | no |
 | repl\_cidr | A custom IP address range over which Replicated will communicate, expressed in CIDR notation. | `string` | `""` | no |
 | ssh\_import\_id\_usernames | The usernames associated with SSH keys which will be imported from a keyserver to all machines. Refer to the cloud-init documentation for more information: https://cloudinit.readthedocs.io/en/latest/topics/modules.html#ssh-import-id | `list(string)` | `[]` | no |

--- a/modules/cloud-init/variables.tf
+++ b/modules/cloud-init/variables.tf
@@ -50,7 +50,7 @@ variable "proxy_url" {
 }
 
 variable "ptfe_url" {
-  default     = "https://install.terraform.io/installer/ptfe-0.1.zip"
+  default     = "https://install.terraform.io/installer/ptfe-stable.zip"
   description = "The URL of the cluster installer tool."
   type        = string
 }


### PR DESCRIPTION
## Background

This branch updates the PTFE url to default to ptfe-stable.zip. The commit was missed in #62.


Relates #38 #62


## How Has This Been Tested

This was tested as part of #62.

### Test Configuration

* Terraform Version: 0.12.17



## This PR makes me feel

![Robot tripping](https://media2.giphy.com/media/D0phJbyJNTEQg/giphy.gif?cid=5a38a5a20b5ecef20a8ca234bdb95697c9511dca8389129a&rid=giphy.gif)
