### PR TITLE
Increase dashboard timeout to 5 minutes

### DIFF
--- a/modules/external-load-balancer/main.tf
+++ b/modules/external-load-balancer/main.tf
@@ -64,7 +64,7 @@ resource "google_compute_backend_service" "install_dashboard" {
   }
   port_name   = "install-dashboard"
   protocol    = "TCP"
-  timeout_sec = 10
+  timeout_sec = 300
 }
 
 resource "google_compute_url_map" "main" {


### PR DESCRIPTION
## Background

Requesting a support bundle results in an 5XX series error. This branch increases the connection timeout for the install dashboard in order to allow support bundle requests to be properly processed.

Relates #38 
[Asana task](https://app.asana.com/0/1168960898522641/1172263022406361/f)

## How Has This Been Tested

I updated the root example to source the root module from the filesystem, deployed the example cluster, and verified that I could download a support bundle.

### Test Configuration

* Terraform Version: 0.12.17

## This PR makes me feel

![Mr. Bean waiting](https://media0.giphy.com/media/pFZTlrO0MV6LoWSDXd/giphy.gif?cid=5a38a5a267fcc7b2ece121ed8461145937fa40bf4b638f10&rid=giphy.gif)

