### PR TITLE
Deploy primaries in regional manner

### DIFF
--- a/examples/proxy/main.tf
+++ b/examples/proxy/main.tf
@@ -98,15 +98,15 @@ module "primaries" {
 module "internal_load_balancer" {
   source = "hashicorp/terraform-enterprise/google//modules/internal-load-balancer"
 
-  prefix                             = var.prefix
-  primaries_instance_group_self_link = module.primaries.instance_group.self_link
-  service_account_email              = module.service_account.internal_load_balancer.email
-  vpc_cluster_assistant_tcp_port     = module.vpc.cluster_assistant_tcp_port
-  vpc_kubernetes_tcp_port            = module.vpc.kubernetes_tcp_port
-  vpc_network_self_link              = module.vpc.network.self_link
-  vpc_subnetwork_ip_cidr_range       = module.vpc.subnetwork.ip_cidr_range
-  vpc_subnetwork_project             = module.vpc.subnetwork.project
-  vpc_subnetwork_self_link           = module.vpc.subnetwork.self_link
+  prefix                               = var.prefix
+  primaries_instance_groups_self_links = module.primaries.instance_groups[*].self_link
+  service_account_email                = module.service_account.internal_load_balancer.email
+  vpc_cluster_assistant_tcp_port       = module.vpc.cluster_assistant_tcp_port
+  vpc_kubernetes_tcp_port              = module.vpc.kubernetes_tcp_port
+  vpc_network_self_link                = module.vpc.network.self_link
+  vpc_subnetwork_ip_cidr_range         = module.vpc.subnetwork.ip_cidr_range
+  vpc_subnetwork_project               = module.vpc.subnetwork.project
+  vpc_subnetwork_self_link             = module.vpc.subnetwork.self_link
 
   labels = var.labels
 }
@@ -133,7 +133,7 @@ module "external_load_balancer" {
   source = "hashicorp/terraform-enterprise/google//modules/external-load-balancer"
 
   prefix                                            = var.prefix
-  primaries_instance_group_self_link                = module.primaries.instance_group.self_link
+  primaries_instance_groups_self_links              = module.primaries.instance_groups[*].self_link
   secondaries_instance_group_manager_instance_group = module.secondaries.instance_group_manager.instance_group
   ssl_certificate_self_link                         = module.ssl.certificate.self_link
   ssl_policy_self_link                              = module.ssl.policy.self_link

--- a/examples/shared-vpc/modules/service/main.tf
+++ b/examples/shared-vpc/modules/service/main.tf
@@ -66,15 +66,15 @@ module "primaries" {
 module "internal_load_balancer" {
   source = "hashicorp/terraform-enterprise/google//modules/internal-load-balancer"
 
-  prefix                             = var.prefix
-  primaries_instance_group_self_link = module.primaries.instance_group.self_link
-  service_account_email              = var.service_account_internal_load_balancer_email
-  vpc_cluster_assistant_tcp_port     = var.vpc_cluster_assistant_tcp_port
-  vpc_kubernetes_tcp_port            = var.vpc_kubernetes_tcp_port
-  vpc_network_self_link              = var.vpc_network_self_link
-  vpc_subnetwork_ip_cidr_range       = var.vpc_subnetwork_ip_cidr_range
-  vpc_subnetwork_project             = var.vpc_subnetwork_project
-  vpc_subnetwork_self_link           = var.vpc_subnetwork_self_link
+  prefix                               = var.prefix
+  primaries_instance_groups_self_links = module.primaries.instance_groups[*].self_link
+  service_account_email                = var.service_account_internal_load_balancer_email
+  vpc_cluster_assistant_tcp_port       = var.vpc_cluster_assistant_tcp_port
+  vpc_kubernetes_tcp_port              = var.vpc_kubernetes_tcp_port
+  vpc_network_self_link                = var.vpc_network_self_link
+  vpc_subnetwork_ip_cidr_range         = var.vpc_subnetwork_ip_cidr_range
+  vpc_subnetwork_project               = var.vpc_subnetwork_project
+  vpc_subnetwork_self_link             = var.vpc_subnetwork_self_link
 
   labels = var.labels
 }
@@ -101,7 +101,7 @@ module "external_load_balancer" {
   source = "hashicorp/terraform-enterprise/google//modules/external-load-balancer"
 
   prefix                                            = var.prefix
-  primaries_instance_group_self_link                = module.primaries.instance_group.self_link
+  primaries_instance_groups_self_links              = module.primaries.instance_groups[*].self_link
   secondaries_instance_group_manager_instance_group = module.secondaries.instance_group_manager.instance_group
   ssl_certificate_self_link                         = module.ssl.certificate.self_link
   ssl_policy_self_link                              = module.ssl.policy.self_link

--- a/main.tf
+++ b/main.tf
@@ -83,15 +83,15 @@ module "primaries" {
 module "internal_load_balancer" {
   source = "./modules/internal-load-balancer"
 
-  prefix                             = var.prefix
-  primaries_instance_group_self_link = module.primaries.instance_group.self_link
-  service_account_email              = module.service_account.internal_load_balancer.email
-  vpc_cluster_assistant_tcp_port     = module.vpc.cluster_assistant_tcp_port
-  vpc_kubernetes_tcp_port            = module.vpc.kubernetes_tcp_port
-  vpc_network_self_link              = module.vpc.network.self_link
-  vpc_subnetwork_ip_cidr_range       = module.vpc.subnetwork.ip_cidr_range
-  vpc_subnetwork_project             = module.vpc.subnetwork.project
-  vpc_subnetwork_self_link           = module.vpc.subnetwork.self_link
+  prefix                               = var.prefix
+  primaries_instance_groups_self_links = module.primaries.instance_groups[*].self_link
+  service_account_email                = module.service_account.internal_load_balancer.email
+  vpc_cluster_assistant_tcp_port       = module.vpc.cluster_assistant_tcp_port
+  vpc_kubernetes_tcp_port              = module.vpc.kubernetes_tcp_port
+  vpc_network_self_link                = module.vpc.network.self_link
+  vpc_subnetwork_ip_cidr_range         = module.vpc.subnetwork.ip_cidr_range
+  vpc_subnetwork_project               = module.vpc.subnetwork.project
+  vpc_subnetwork_self_link             = module.vpc.subnetwork.self_link
 
   labels = var.labels
 }
@@ -118,7 +118,7 @@ module "external_load_balancer" {
   source = "./modules/external-load-balancer"
 
   prefix                                            = var.prefix
-  primaries_instance_group_self_link                = module.primaries.instance_group.self_link
+  primaries_instance_groups_self_links              = module.primaries.instance_groups[*].self_link
   secondaries_instance_group_manager_instance_group = module.secondaries.instance_group_manager.instance_group
   ssl_certificate_self_link                         = module.ssl.certificate.self_link
   ssl_policy_self_link                              = module.ssl.policy.self_link

--- a/modules/external-load-balancer/docs/inputs.md
+++ b/modules/external-load-balancer/docs/inputs.md
@@ -5,7 +5,7 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:-----:|
 | prefix | The prefix which will be prepended to the names of resources. | `string` | n/a | yes |
-| primaries\_instance\_group\_self\_link | The self link of the compute instance group for the primaries. | `string` | n/a | yes |
+| primaries\_instance\_groups\_self\_links | The self links of the compute instance groups which comprise the primaries. | `list(string)` | n/a | yes |
 | secondaries\_instance\_group\_manager\_instance\_group | The compute instance group of the secondaries. | `string` | n/a | yes |
 | ssl\_certificate\_self\_link | The self link of the managed SSL certificate which will be applied to the load balancer. | `string` | n/a | yes |
 | ssl\_policy\_self\_link | The self link of a compute SSL policy for the SSL certificate. | `string` | n/a | yes |

--- a/modules/external-load-balancer/main.tf
+++ b/modules/external-load-balancer/main.tf
@@ -14,18 +14,21 @@ resource "google_compute_backend_service" "application" {
   health_checks = [google_compute_health_check.application.self_link]
   name          = "${var.prefix}application"
 
-  backend {
-    group = var.primaries_instance_group_self_link
+  dynamic "backend" {
+    for_each = var.primaries_instance_groups_self_links
+    content {
+      group = backend.value
 
-    balancing_mode        = "RATE"
-    description           = "The TFE primaries."
-    max_rate_per_instance = 333
+      balancing_mode        = "RATE"
+      description           = "A group of compute instances which comprises some of the TFE primaries."
+      max_rate_per_instance = 333
+    }
   }
   backend {
     group = var.secondaries_instance_group_manager_instance_group
 
     balancing_mode        = "RATE"
-    description           = "The TFE secondaries."
+    description           = "A group of compute instances which comprises the TFE secondaries."
     max_rate_per_instance = 333
   }
   port_name   = "application"
@@ -48,18 +51,21 @@ resource "google_compute_backend_service" "install_dashboard" {
   health_checks = [google_compute_health_check.install_dashboard.self_link]
   name          = "${var.prefix}install-dashboard"
 
-  backend {
-    group = var.primaries_instance_group_self_link
+  dynamic "backend" {
+    for_each = var.primaries_instance_groups_self_links
+    content {
+      group = backend.value
 
-    balancing_mode               = "CONNECTION"
-    description                  = "The TFE primaries."
-    max_connections_per_instance = 10
+      balancing_mode               = "CONNECTION"
+      description                  = "A group of compute instances which comprises some of the TFE primaries."
+      max_connections_per_instance = 10
+    }
   }
   backend {
     group = var.secondaries_instance_group_manager_instance_group
 
     balancing_mode               = "CONNECTION"
-    description                  = "The TFE secondaries."
+    description                  = "A group of compute instances which comprises the TFE secondaries."
     max_connections_per_instance = 10
   }
   port_name   = "install-dashboard"

--- a/modules/external-load-balancer/variables.tf
+++ b/modules/external-load-balancer/variables.tf
@@ -3,9 +3,9 @@ variable "prefix" {
   type        = string
 }
 
-variable "primaries_instance_group_self_link" {
-  description = "The self link of the compute instance group for the primaries."
-  type        = string
+variable "primaries_instance_groups_self_links" {
+  description = "The self links of the compute instance groups which comprise the primaries."
+  type        = list(string)
 }
 
 variable "secondaries_instance_group_manager_instance_group" {

--- a/modules/internal-load-balancer/docs/inputs.md
+++ b/modules/internal-load-balancer/docs/inputs.md
@@ -5,7 +5,7 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:-----:|
 | prefix | The prefix which will be prepended to the names of resources. | `string` | n/a | yes |
-| primaries\_instance\_group\_self\_link | The self link of the instance group for the primaries. | `string` | n/a | yes |
+| primaries\_instance\_groups\_self\_links | The self links of the instance groups which comprise the primaries. | `list(string)` | n/a | yes |
 | service\_account\_email | The email address of the service account which will be associated with the proxy compute instances. | `string` | n/a | yes |
 | vpc\_cluster\_assistant\_tcp\_port | The port over which Cluster Assistant TCP traffic will travel. | `string` | n/a | yes |
 | vpc\_kubernetes\_tcp\_port | The port over which Kubernetes TCP traffic will travel. | `string` | n/a | yes |

--- a/modules/internal-load-balancer/main.tf
+++ b/modules/internal-load-balancer/main.tf
@@ -20,10 +20,13 @@ resource "google_compute_region_backend_service" "internal_load_balancer_out" {
   health_checks = [google_compute_health_check.internal_load_balancer_out.self_link]
   name          = local.name_out
 
-  backend {
-    group = var.primaries_instance_group_self_link
+  dynamic "backend" {
+    for_each = var.primaries_instance_groups_self_links
+    content {
+      group = backend.value
 
-    description = "Target the TFE primaries."
+      description = "A group of compute instances which comprises some of the TFE primaries."
+    }
   }
   description = "Serve to the TFE primaries egress traffic from the internal load balancer."
   protocol    = "TCP"

--- a/modules/internal-load-balancer/variables.tf
+++ b/modules/internal-load-balancer/variables.tf
@@ -4,6 +4,21 @@ variable "labels" {
   type        = map(string)
 }
 
+variable "prefix" {
+  description = "The prefix which will be prepended to the names of resources."
+  type        = string
+}
+
+variable "primaries_instance_groups_self_links" {
+  description = "The self links of the instance groups which comprise the primaries."
+  type        = list(string)
+}
+
+variable "service_account_email" {
+  type        = string
+  description = "The email address of the service account which will be associated with the proxy compute instances."
+}
+
 variable "vpc_cluster_assistant_tcp_port" {
   description = "The port over which Cluster Assistant TCP traffic will travel."
   type        = string
@@ -14,8 +29,8 @@ variable "vpc_kubernetes_tcp_port" {
   type        = string
 }
 
-variable "prefix" {
-  description = "The prefix which will be prepended to the names of resources."
+variable "vpc_network_self_link" {
+  description = "The self link of the network to which resources will be attached."
   type        = string
 }
 
@@ -24,27 +39,12 @@ variable "vpc_subnetwork_ip_cidr_range" {
   type        = string
 }
 
-variable "primaries_instance_group_self_link" {
-  type        = string
-  description = "The self link of the instance group for the primaries."
-}
-
-variable "service_account_email" {
-  type        = string
-  description = "The email address of the service account which will be associated with the proxy compute instances."
-}
-
-variable "vpc_network_self_link" {
-  description = "The self link of the network to which resources will be attached."
+variable "vpc_subnetwork_project" {
+  description = "The ID of the project in which var.vpc_subnetwork_self_link exists."
   type        = string
 }
 
 variable "vpc_subnetwork_self_link" {
   description = "The self link of the subnetwork to which resources will be attached. The subnetwork must be part of var.vpc_network_self_link."
-  type        = string
-}
-
-variable "vpc_subnetwork_project" {
-  description = "The ID of the project in which var.vpc_subnetwork_self_link exists."
   type        = string
 }

--- a/modules/primaries/docs/outputs.md
+++ b/modules/primaries/docs/outputs.md
@@ -4,6 +4,5 @@
 
 | Name | Description |
 |------|-------------|
-| instance\_group | The compute instance group for the cluster. |
-| instances | The compute instances which comprise the cluster. |
+| instance\_groups | The groups of compute instances which comprise the primaries. |
 

--- a/modules/primaries/outputs.tf
+++ b/modules/primaries/outputs.tf
@@ -1,11 +1,5 @@
-output "instances" {
-  value = google_compute_instance.main
-
-  description = "The compute instances which comprise the cluster."
-}
-
-output "instance_group" {
+output "instance_groups" {
   value = google_compute_instance_group.main
 
-  description = "The compute instance group for the cluster."
+  description = "The groups of compute instances which comprise the primaries."
 }


### PR DESCRIPTION
## Background

Users have requested that all compute instance groups be deployed in a regional manner to improve redundancy and disaster mitigation. The primaries were the only group which were not already deployed in this manner; this branch changes that.


Relates #38 
[Asana task](https://app.asana.com/0/1170474914009329/1156584069212417/f)


## How Has This Been Tested

I deployed the root example with the source altered to the local pathname of the root module. I verified that the pods came up correctly and each primary was deployed to a different zone.

### Test Configuration

* Terraform Version: 0.12.17

## This PR makes me feel


![104.7 RegionalFM](https://media2.giphy.com/media/C8YUqqeDLTSat8O03v/giphy.gif?cid=5a38a5a22cfbf7f20f0a546040b22213d029cf24e62c6eb4&rid=giphy.gif)

