### PR TITLE
Add hooks for pre-install script and post-install script to install-ptfe.sh

### DIFF
--- a/modules/cloud-init/docs/inputs.md
+++ b/modules/cloud-init/docs/inputs.md
@@ -14,6 +14,7 @@
 | airgap\_installer\_url | The URL of an airgap package which contains the cluster installer. | `string` | `"https://install.terraform.io/installer/replicated-v5.tar.gz"` | no |
 | airgap\_package\_url | The URL of an airgap package which contains a TFE release. | `string` | `""` | no |
 | custom\_ca\_cert\_url | The URL of a certificate authority bundle which contains custom certificates to be trusted by the application. | `string` | `""` | no |
+| custom\_shell\_script | A custom shell script which will be invoked prior to starting or joining the cluster. | `string` | `"echo 'A custom shell script was not provided.'"` | no |
 | distribution | The type of Linux distribution which will be running on the machines. | `string` | `"ubuntu"` | no |
 | proxy\_url | The URL of a proxy through which application traffic will be routed. | `string` | `""` | no |
 | ptfe\_url | The URL of the cluster installer tool. | `string` | `"https://install.terraform.io/installer/ptfe-0.1.zip"` | no |

--- a/modules/cloud-init/docs/inputs.md
+++ b/modules/cloud-init/docs/inputs.md
@@ -14,8 +14,9 @@
 | airgap\_installer\_url | The URL of an airgap package which contains the cluster installer. | `string` | `"https://install.terraform.io/installer/replicated-v5.tar.gz"` | no |
 | airgap\_package\_url | The URL of an airgap package which contains a TFE release. | `string` | `""` | no |
 | custom\_ca\_cert\_url | The URL of a certificate authority bundle which contains custom certificates to be trusted by the application. | `string` | `""` | no |
-| custom\_shell\_script | A custom shell script which will be invoked prior to starting or joining the cluster. | `string` | `"echo 'A custom shell script was not provided.'"` | no |
 | distribution | The type of Linux distribution which will be running on the machines. | `string` | `"ubuntu"` | no |
+| postinstall\_script | A custom shell script which will be invoked after TFE is installed. | `string` | `"echo 'A post-install script was not provided.'"` | no |
+| preinstall\_script | A custom shell script which will be invoked before TFE is installed. | `string` | `"echo 'A pre-install script was not provided.'"` | no |
 | proxy\_url | The URL of a proxy through which application traffic will be routed. | `string` | `""` | no |
 | ptfe\_url | The URL of the cluster installer tool. | `string` | `"https://install.terraform.io/installer/ptfe-0.1.zip"` | no |
 | release\_sequence | The sequence identifier of the TFE version to which the cluster will be pinned. | `string` | `"latest"` | no |

--- a/modules/cloud-init/files/install-ptfe.sh
+++ b/modules/cloud-init/files/install-ptfe.sh
@@ -2,6 +2,9 @@
 
 set -e -u -o pipefail
 
+echo "Executing the pre-install script..."
+/bin/bash /etc/ptfe/pre-install.sh
+
 ### Set proxy variables, if needed.
 if [ -s /etc/ptfe/proxy-url ]; then
   http_proxy=$(cat /etc/ptfe/proxy-url)
@@ -74,9 +77,6 @@ pushd /tmp
   cp ptfe /usr/bin
   chmod a+x /usr/bin/ptfe
 popd
-
-echo "Executing the custom shell script..."
-/bin/bash /etc/ptfe/custom-shell-script.sh
 
 role="$(cat /etc/ptfe/role)"
 export role
@@ -253,3 +253,6 @@ fi
 
 echo "Running 'ptfe install $verb"  "${ptfe_install_args[@]}" "'"
 ptfe install $verb "${ptfe_install_args[@]}"
+
+echo "Executing the post-install script..."
+/bin/bash /etc/ptfe/post-install.sh

--- a/modules/cloud-init/files/install-ptfe.sh
+++ b/modules/cloud-init/files/install-ptfe.sh
@@ -75,6 +75,9 @@ pushd /tmp
   chmod a+x /usr/bin/ptfe
 popd
 
+echo "Executing the custom shell script..."
+/bin/bash /etc/ptfe/custom-shell-script.sh
+
 role="$(cat /etc/ptfe/role)"
 export role
 

--- a/modules/cloud-init/main.tf
+++ b/modules/cloud-init/main.tf
@@ -11,10 +11,11 @@ locals {
       )
       cluster_api_endpoint    = "${var.internal_load_balancer_in_address}:${var.vpc_kubernetes_tcp_port}"
       custom_ca_cert_url      = var.custom_ca_cert_url
-      custom_shell_script     = var.custom_shell_script
       distribution            = var.distribution
       health_url              = "${local.assistant_host}/healthz"
       install_ptfe_sh         = file("${path.module}/files/install-ptfe.sh")
+      postinstall_script      = var.postinstall_script
+      preinstall_script       = var.preinstall_script
       proxy_conf              = templatefile("${path.module}/templates/proxy.conf.tmpl", { proxy_url = var.proxy_url })
       proxy_url               = var.proxy_url
       ptfe_url                = var.ptfe_url

--- a/modules/cloud-init/main.tf
+++ b/modules/cloud-init/main.tf
@@ -11,6 +11,7 @@ locals {
       )
       cluster_api_endpoint    = "${var.internal_load_balancer_in_address}:${var.vpc_kubernetes_tcp_port}"
       custom_ca_cert_url      = var.custom_ca_cert_url
+      custom_shell_script     = var.custom_shell_script
       distribution            = var.distribution
       health_url              = "${local.assistant_host}/healthz"
       install_ptfe_sh         = file("${path.module}/files/install-ptfe.sh")

--- a/modules/cloud-init/templates/base-cloud-config.yaml.tmpl
+++ b/modules/cloud-init/templates/base-cloud-config.yaml.tmpl
@@ -70,11 +70,17 @@ write_files:
   encoding: b64
   content: "${base64encode(additional_no_proxy)}"
 
-- path: /etc/ptfe/custom-shell-script.sh
+- path: /etc/ptfe/post-install.sh
   owner: root:root
   permissions: "0500"
   encoding: b64
-  content: "${base64encode(custom_shell_script)}"
+  content: "${base64encode(postinstall_script)}"
+
+- path: /etc/ptfe/pre-install.sh
+  owner: root:root
+  permissions: "0500"
+  encoding: b64
+  content: "${base64encode(preinstall_script)}"
 %{ if custom_ca_cert_url != "" ~}
 
 - path: /etc/ptfe/custom-ca-cert-url

--- a/modules/cloud-init/templates/base-cloud-config.yaml.tmpl
+++ b/modules/cloud-init/templates/base-cloud-config.yaml.tmpl
@@ -69,6 +69,12 @@ write_files:
   permissions: "0400"
   encoding: b64
   content: "${base64encode(additional_no_proxy)}"
+
+- path: /etc/ptfe/custom-shell-script.sh
+  owner: root:root
+  permissions: "0500"
+  encoding: b64
+  content: "${base64encode(custom_shell_script)}"
 %{ if custom_ca_cert_url != "" ~}
 
 - path: /etc/ptfe/custom-ca-cert-url

--- a/modules/cloud-init/variables.tf
+++ b/modules/cloud-init/variables.tf
@@ -27,6 +27,12 @@ variable "custom_ca_cert_url" {
   type        = string
 }
 
+variable "custom_shell_script" {
+  default     = "echo 'A custom shell script was not provided.'"
+  description = "A custom shell script which will be invoked prior to starting or joining the cluster."
+  type        = string
+}
+
 variable "distribution" {
   default     = "ubuntu"
   description = "The type of Linux distribution which will be running on the machines."

--- a/modules/cloud-init/variables.tf
+++ b/modules/cloud-init/variables.tf
@@ -27,12 +27,6 @@ variable "custom_ca_cert_url" {
   type        = string
 }
 
-variable "custom_shell_script" {
-  default     = "echo 'A custom shell script was not provided.'"
-  description = "A custom shell script which will be invoked prior to starting or joining the cluster."
-  type        = string
-}
-
 variable "distribution" {
   default     = "ubuntu"
   description = "The type of Linux distribution which will be running on the machines."
@@ -46,6 +40,18 @@ variable "internal_load_balancer_in_address" {
 
 variable "license_file" {
   description = "The pathname of a Replicated license file for the application."
+  type        = string
+}
+
+variable "postinstall_script" {
+  default     = "echo 'A post-install script was not provided.'"
+  description = "A custom shell script which will be invoked after TFE is installed."
+  type        = string
+}
+
+variable "preinstall_script" {
+  default     = "echo 'A pre-install script was not provided.'"
+  description = "A custom shell script which will be invoked before TFE is installed."
   type        = string
 }
 


### PR DESCRIPTION
## Background

Users have requested the ability to inject custom commands in to `install-ptfe.sh`. This branch adds ~a variable which defines a custom shell script to be executed prior to invoking `ptfe install`~ variables which define a pre-install script and post-install script which are executed at the beginning and the end of `install-ptfe.sh`.


[Asana task](https://app.asana.com/0/1170474914009329/1158789214132833/f)


## How Has This Been Tested

I deployed TFE using the root example and verified that the default ~custom script was~ scripts were executed on multiple compute instances.

### Test Configuration

* Terraform Version: 0.12.17

## This PR makes me feel

![To accurately portray my unique and quirky home life.](https://media1.giphy.com/media/3orieTaQwR627a9iA8/giphy.gif?cid=5a38a5a2603a431d5ead40d55f1afe5adaeec97e35a986b4&rid=giphy.gif)
