### PR TITLE
Miscellaneous updates to align with documentation

### DIFF
--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -8,7 +8,7 @@
 | dns\_managed\_zone | The name of the managed DNS zone in which the application will be accessible. | `string` | n/a | yes |
 | dns\_managed\_zone\_dns\_name | The fully qualified DNS name of the managed zone set by var.dns\_managed\_zone. | `string` | n/a | yes |
 | labels | A collection of labels which will be applied to resources. | `map(string)` | `{}` | no |
-| secondaries\_max\_instances | The maximum count of compute instances to which the secondaries may scale. The default value is deferred to the secondaries submodule. | `number` | n/a | yes |
-| secondaries\_min\_instances | The minimum count of compute instances to which the secondaries may scale. The default value is deferred to the secondaries submodule. | `number` | n/a | yes |
 | prefix | The prefix which will be prepended to the names of resources. | `string` | `"tfe-"` | no |
+| secondaries\_max\_instances | The maximum count of compute instances to which the secondaries may scale. The default value is derived from the secondaries submodule. | `number` | `5` | no |
+| secondaries\_min\_instances | The minimum count of compute instances to which the secondaries may scale. The default value is derived from the secondaries submodule. | `number` | `1` | no |
 

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -8,5 +8,7 @@
 | dns\_managed\_zone | The name of the managed DNS zone in which the application will be accessible. | `string` | n/a | yes |
 | dns\_managed\_zone\_dns\_name | The fully qualified DNS name of the managed zone set by var.dns\_managed\_zone. | `string` | n/a | yes |
 | labels | A collection of labels which will be applied to resources. | `map(string)` | `{}` | no |
+| secondaries\_max\_instances | The maximum count of compute instances to which the secondaries may scale. The default value is deferred to the secondaries submodule. | `number` | n/a | yes |
+| secondaries\_min\_instances | The minimum count of compute instances to which the secondaries may scale. The default value is deferred to the secondaries submodule. | `number` | n/a | yes |
 | prefix | The prefix which will be prepended to the names of resources. | `string` | `"tfe-"` | no |
 

--- a/main.tf
+++ b/main.tf
@@ -110,7 +110,7 @@ module "secondaries" {
   vpc_subnetwork_project         = module.vpc.subnetwork.project
   vpc_subnetwork_self_link       = module.vpc.subnetwork.self_link
 
-  labels = var.labels
+  labels        = var.labels
   max_instances = var.secondaries_max_instances
   min_instances = var.secondaries_min_instances
 }

--- a/main.tf
+++ b/main.tf
@@ -111,6 +111,8 @@ module "secondaries" {
   vpc_subnetwork_self_link       = module.vpc.subnetwork.self_link
 
   labels = var.labels
+  max_instances = var.secondaries_max_instances
+  min_instances = var.secondaries_min_instances
 }
 
 # Create an external load balancer which directs traffic to the primaries.

--- a/modules/postgresql/docs/inputs.md
+++ b/modules/postgresql/docs/inputs.md
@@ -9,7 +9,7 @@
 | prefix | The prefix which will be prepended to the names of resources. | `string` | n/a | yes |
 | vpc\_address\_name | n/a | `string` | n/a | yes |
 | vpc\_network\_self\_link | The self link of the network to which resources will be attached. | `string` | n/a | yes |
-| availability\_type | A specifier which determines if the database compute instance will be set up for high availability (REGIONAL) or single zone (ZONAL). | `string` | `"ZONAL"` | no |
+| availability\_type | A specifier which determines if the database compute instance will be set up for high availability (REGIONAL) or single zone (ZONAL). | `string` | `"REGIONAL"` | no |
 | labels | A collection of labels which will be applied to the database compute instance. | `map(string)` | `{}` | no |
 | machine\_type | The identifier of the set of virtualized hardware resources which will be available to the database compute instance. | `string` | `"db-custom-2-13312"` | no |
 | name | The name of the database which will be used to store application data. | `string` | `"tfe"` | no |

--- a/modules/postgresql/variables.tf
+++ b/modules/postgresql/variables.tf
@@ -1,5 +1,5 @@
 variable "availability_type" {
-  default     = "ZONAL"
+  default     = "REGIONAL"
   description = "A specifier which determines if the database compute instance will be set up for high availability (REGIONAL) or single zone (ZONAL)."
   type        = string
 }

--- a/modules/primaries/main.tf
+++ b/modules/primaries/main.tf
@@ -27,7 +27,7 @@ resource "google_compute_instance" "main" {
   zone = element(data.google_compute_zones.up.names, count.index)
 
   allow_stopping_for_update = true
-  description               = "The compute instance which acts as TFE Primary ${count.index}."
+  description               = "The compute instance which acts as TFE primary ${count.index}."
   labels                    = var.labels
   metadata = {
     user-data          = var.cloud_init_configs[count.index]
@@ -44,7 +44,7 @@ resource "google_compute_instance_group" "main" {
   count = local.instance_count
 
   name        = "${var.prefix}primary-${count.index}"
-  description = "The group comprising the compute instance which acts as TFE Primary ${count.index}."
+  description = "The group comprising the compute instance which acts as TFE primary ${count.index}."
   zone        = google_compute_instance.main[count.index].zone
 
   instances = [google_compute_instance.main[count.index].self_link]

--- a/variables.tf
+++ b/variables.tf
@@ -24,3 +24,15 @@ variable "prefix" {
   description = "The prefix which will be prepended to the names of resources."
   type        = string
 }
+
+variable "secondaries_max_instances" {
+  default     = 5
+  description = "The maximum count of compute instances to which the secondaries may scale. The default value is deferred to the secondaries submodule."
+  type        = number
+}
+
+variable "secondaries_min_instances" {
+  default     = 1
+  description = "The minimum count of compute instances to which the secondaries may scale. The default value is deferred to the secondaries submodule."
+  type        = number
+}

--- a/variables.tf
+++ b/variables.tf
@@ -27,12 +27,12 @@ variable "prefix" {
 
 variable "secondaries_max_instances" {
   default     = 5
-  description = "The maximum count of compute instances to which the secondaries may scale. The default value is deferred to the secondaries submodule."
+  description = "The maximum count of compute instances to which the secondaries may scale. The default value is derived from the secondaries submodule."
   type        = number
 }
 
 variable "secondaries_min_instances" {
   default     = 1
-  description = "The minimum count of compute instances to which the secondaries may scale. The default value is deferred to the secondaries submodule."
+  description = "The minimum count of compute instances to which the secondaries may scale. The default value is derived from the secondaries submodule."
   type        = number
 }


### PR DESCRIPTION
## Background

This branch includes miscellaneous updates which align the module with terraform.io documentation.

- add secondary count inputs to the root module
- deploy PostgreSQL regionally
- consistently uncapitalize "primary" and "secondary", except for names
- rename ILB "nodes" to "routers" for clarity (not documentation related)

## How Has This Been Tested

I provisioned an environment using the root module.

### Test Configuration

* Terraform Version: 0.12.17

## This PR makes me feel


![Gromit reading](https://media0.giphy.com/media/34ZNcoaN5u4hi/giphy.gif?cid=5a38a5a2e6613cae1fe4726de82b966e43a578c141a92aa0&rid=giphy.gif)
