### PR TITLE
Fix pinning release sequence

### DIFF
--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -9,7 +9,7 @@
 | dns\_managed\_zone\_dns\_name | The fully qualified DNS name of the managed zone set by var.dns\_managed\_zone. | `string` | n/a | yes |
 | labels | A collection of labels which will be applied to resources. | `map(string)` | `{}` | no |
 | prefix | The prefix which will be prepended to the names of resources. | `string` | `"tfe-"` | no |
-| release_sequence | The sequence identifier of the TFE version to which the cluster will be pinned. | `string` | `"latest"` | no |
+| release\_sequence | The sequence identifier of the TFE version to which the cluster will be pinned. | `string` | `"latest"` | no |
 | secondaries\_max\_instances | The maximum count of compute instances to which the secondaries may scale. The default value is derived from the secondaries submodule. | `number` | `5` | no |
 | secondaries\_min\_instances | The minimum count of compute instances to which the secondaries may scale. The default value is derived from the secondaries submodule. | `number` | `1` | no |
 

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -9,6 +9,7 @@
 | dns\_managed\_zone\_dns\_name | The fully qualified DNS name of the managed zone set by var.dns\_managed\_zone. | `string` | n/a | yes |
 | labels | A collection of labels which will be applied to resources. | `map(string)` | `{}` | no |
 | prefix | The prefix which will be prepended to the names of resources. | `string` | `"tfe-"` | no |
+| release_sequence | The sequence identifier of the TFE version to which the cluster will be pinned. | `string` | `"latest"` | no |
 | secondaries\_max\_instances | The maximum count of compute instances to which the secondaries may scale. The default value is derived from the secondaries submodule. | `number` | `5` | no |
 | secondaries\_min\_instances | The minimum count of compute instances to which the secondaries may scale. The default value is derived from the secondaries submodule. | `number` | `1` | no |
 

--- a/main.tf
+++ b/main.tf
@@ -61,6 +61,7 @@ module "cloud_init" {
   vpc_cluster_assistant_tcp_port                 = module.vpc.cluster_assistant_tcp_port
   vpc_install_dashboard_tcp_port                 = module.vpc.install_dashboard_tcp_port
   vpc_kubernetes_tcp_port                        = module.vpc.kubernetes_tcp_port
+  release_sequence                               = var.release_sequence
 }
 
 # Create the primaries.

--- a/modules/cloud-init/templates/replicated.conf.tmpl
+++ b/modules/cloud-init/templates/replicated.conf.tmpl
@@ -1,6 +1,6 @@
 {
 %{ if release_sequence != "latest" ~}
-    "ReleaseSequence":                   "${release_sequence}",
+    "ReleaseSequence":                   ${release_sequence},
 %{ endif ~}
     "HttpProxy":                         "${proxy_url}",
 %{ if airgap == true ~}

--- a/modules/internal-load-balancer/docs/inputs.md
+++ b/modules/internal-load-balancer/docs/inputs.md
@@ -15,5 +15,5 @@
 | disk\_image | The image from which the main compute instance disks will be initialized. The supported images are: ubuntu-1604-lts; ubuntu-1804-lts; rhel-7. | `string` | `"ubuntu-1804-lts"` | no |
 | disk\_size | The size of var.disk\_image, expressed in units of gigabytes. | `number` | `40` | no |
 | labels | The labels which will be applied to the compute instances. | `map(string)` | `{}` | no |
-| machine\_type | The identifier of the set of virtualized hardware resources which will be available to the compute instances. | `string` | `"n1-standard-8"` | no |
+| machine\_type | The identifier of the set of virtualized hardware resources which will be available to the compute instances. More details on machine types can be found at https://cloud.google.com/compute/docs/machine-types | `string` | `"n1-standard-8"` | no |
 

--- a/modules/internal-load-balancer/versions.tf
+++ b/modules/internal-load-balancer/versions.tf
@@ -1,1 +1,1 @@
-/home/aaronlane/Documents/terraform-google-terraform-enterprise/versions.tf
+../../versions.tf

--- a/variables.tf
+++ b/variables.tf
@@ -25,6 +25,12 @@ variable "prefix" {
   type        = string
 }
 
+variable "release_sequence" {
+  default     = "latest"
+  description = "The sequence identifier of the TFE version to which the cluster will be pinned."
+  type        = string
+}
+
 variable "secondaries_max_instances" {
   default     = 5
   description = "The maximum count of compute instances to which the secondaries may scale. The default value is derived from the secondaries submodule."
@@ -35,10 +41,4 @@ variable "secondaries_min_instances" {
   default     = 1
   description = "The minimum count of compute instances to which the secondaries may scale. The default value is derived from the secondaries submodule."
   type        = number
-}
-
-variable "release_sequence" {
-  default     = ""
-  description = "The sequence identifier of the TFE version to which the cluster will be pinned."
-  type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -36,3 +36,9 @@ variable "secondaries_min_instances" {
   description = "The minimum count of compute instances to which the secondaries may scale. The default value is derived from the secondaries submodule."
   type        = number
 }
+
+variable "release_sequence" {
+  default     = ""
+  description = "The sequence identifier of the TFE version to which the cluster will be pinned."
+  type        = string
+}


### PR DESCRIPTION
## Background

Need to pass a root module variable down to the `cloud-init` module so
that a user can pin the release sequence. Also the value of the
`ReleaseSequence` attribute in the `/etc/replicated.conf` file needs
to be unquoted since it's a JSON number, not a string.

## How Has This Been Tested

Using the `examples/root` configuration.

### Test Configuration

- Terraform 0.12.28

```
provider "google" {
  version     = "3.21.0"
  credentials = file("~/redacted")
  project     = "redacted"
  region      = "redacted"
}

provider "google-beta" {
  version     = "3.21.0"
  credentials = file("~/redacted")
  project     = "redacted"
  region      = "redacted"
}

provider "random" {
  version = "2.1.0"
}

provider "template" {
  version = "2.1.0"
}

module "terraform_enterprise" {
  source = "github.com/hashicorp/terraform-google-terraform-enterprise?ref=sudomateo-sequence-pinning"

  cloud_init_license_file   = var.cloud_init_license_file
  dns_managed_zone          = var.dns_managed_zone
  dns_managed_zone_dns_name = var.dns_managed_zone_dns_name
  prefix                    = var.prefix
  release_sequence          = 39
}
```

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media.giphy.com/media/MxqvW5HnJU3iE/giphy.gif)
