### PR TITLE
Drop config of Docker daemon from install-ptfe.sh

### DIFF
--- a/modules/cloud-init/files/install-ptfe.sh
+++ b/modules/cloud-init/files/install-ptfe.sh
@@ -29,14 +29,6 @@ if [[ $(< /etc/ptfe/additional-no-proxy) != "" ]]; then
   export no_proxy=$no_proxy,$additional_no_proxy
 fi
 
-### Configure Docker to use the systemd control group driver
-mkdir -p /etc/docker
-cat > /etc/docker/daemon.json <<EOF
-{
-  "exec-opts": ["native.cgroupdriver=systemd"]
-}
-EOF
-
 ### Decide on distribution specific things
 if [ -f /etc/redhat-release ]; then
   CONF=/etc/chrony.conf


### PR DESCRIPTION
## Background

Logic to configure the exec-opts of the Docker daemon was added to [ptfe v0.20.0](https://github.com/hashicorp/ptfe/pull/79/files?file-filters%5B%5D=.go#diff-2867dfb8ef216abdf46fa974bbfa957fR1624-R1626). Similar logic was already added to this module, and now this implementation conflicts with ptfe and prevents it from setting up a new cluster.

## How Has This Been Tested

~Testing will commence shortly.~ We redeployed the compute instances of a broken deployment with this patch and saw them start the cluster successfully.

### Test Configuration

* Terraform Version: 0.12

## This PR makes me feel

!["D'oh" montage!](https://media3.giphy.com/media/xT5LMWJSXHRbSusYve/giphy.gif?cid=5a38a5a2x7vhlklqcnn7h0ksmfixa2og7nknesyi4d51n9ao&rid=giphy.gif)

