### PR TITLE
Use docker mirror

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ workflows:
 jobs:
   format_check:
     docker:
-      - image: "hashicorp/terraform:0.11.14"
+      - image: docker.mirror.hashicorp.services/hashicorp/terraform:0.11.14
     steps:
       - checkout
       - run:
@@ -19,7 +19,7 @@ jobs:
   validation_check:
     working_directory: ~
     docker:
-      - image: "hashicorp/terraform:0.11.14"
+      - image: docker.mirror.hashicorp.services/hashicorp/terraform:0.11.14
     steps:
       - checkout
       - run:


### PR DESCRIPTION
CHANGELOG: no impact

Dockerhub is going to rate limit unauthenticated pulls on November 1st. IPs from CI machines will be near their limit all the time. We're moving projects to use a public un-rate-limited Mirror of these images instead. Let me know if you have any q's, otherwise feel free to merge when you can! 
