### PR TITLE
Add ability to specify release sequence

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -124,6 +124,7 @@ module "user_data" {
   redis_pass              = module.redis.password
   redis_port              = module.redis.port
   redis_use_password_auth = var.redis_auth_enabled
+  release_sequence        = var.release_sequence
   active_active           = local.active_active
   proxy_ip                = var.proxy_ip
   proxy_cert              = local.proxy_cert

--- a/modules/user_data/main.tf
+++ b/modules/user_data/main.tf
@@ -254,7 +254,7 @@ locals {
   is_airgap      = var.airgap_url != "" ? local.airgap_config : {}
   is_letsencrypt = var.letsencrypt_email != "" ? local.letsencrypt_config : {}
   is_generic_tls = var.server_cert_path != "" ? local.generic_tls_config : {}
-  is_pinned      = var.release_sequence != "" ? local.release_pin_config : {}
+  is_pinned      = var.release_sequence != 0 ? local.release_pin_config : {}
 
   repl_configs = jsonencode(merge(local.replicated_base_config, local.is_airgap, local.is_letsencrypt, local.is_generic_tls, local.is_pinned))
 }

--- a/modules/user_data/variables.tf
+++ b/modules/user_data/variables.tf
@@ -124,8 +124,11 @@ variable "redis_use_tls" {
 variable "airgap_url" {
   default = ""
 }
+
 variable "release_sequence" {
-  default = ""
+  description = "Release sequence of Terraform Enterprise to install."
+  type        = number
+  default     = 0
 }
 
 

--- a/variables.tf
+++ b/variables.tf
@@ -102,6 +102,12 @@ variable "redis_memory_size" {
   default     = 6
   description = "Redis memory size in GiB"
 }
+# REPLICATED VARS
+variable "release_sequence" {
+  description = "Release sequence of Terraform Enterprise to install."
+  type        = number
+  default     = 0
+}
 # VM VARS
 variable "vm_machine_type" {
   default     = "n1-standard-4"


### PR DESCRIPTION
## Background

This allows the user to pass the release sequence and pin their installation to a specific version of Terraform
Enterprise.

## How Has This Been Tested

By spinning up Terraform Enterprise via the `active/active` example.

### Test Configuration

The `active/active` example.

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media.giphy.com/media/XfIc8q8bPfU08fxcjR/giphy.gif)
