### PR TITLE
Add /test private-active-active

### DIFF
--- a/.github/workflows/handler-destroy.yml
+++ b/.github/workflows/handler-destroy.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   public_active_active:
-    name: Destroy resources from Public Active/Active test
+    name: Destroy resources from Public Active/Active
     if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'public-active-active') }}
     runs-on: ubuntu-latest
     permissions:
@@ -56,6 +56,64 @@ jobs:
           comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
           body: |
             ${{ format('### {0} Terraform Public Active/Active Destruction Report', job.status == 'success' && ':white_check_mark:' || ':x:') }}
+
+            ${{ format(':link: [Action Summary Page]({0})', steps.vars.outputs.run-url) }}
+
+            ${{ format('- {0} Terraform Init', steps.init.outcome == 'success' && ':white_check_mark:' || ':x:') }}
+
+            ${{ format('- {0} Terraform Destroy', steps.destroy.outcome == 'success' && ':white_check_mark:' || ':x:') }}
+
+  private_active_active:
+    name: Destroy resources from Private Active/Active
+    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'private-active-active') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      WORK_DIR_PATH: ./tests/private-active-active
+      AWS_DEFAULT_REGION: us-east-2
+    steps:
+      - name: Create URL to the run output
+        id: vars
+        run: echo ::set-output name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+
+      # Checkout the branch of the pull request being tested
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.client_payload.pull_request.head.sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v1
+        with:
+          cli_config_credentials_hostname: 'app.terraform.io'
+          cli_config_credentials_token: ${{ secrets.PRIVATE_ACTIVE_ACTIVE_TFC_TOKEN }}
+          terraform_version: 0.14.8
+          terraform_wrapper: true
+
+      - name: Terraform Init
+        id: init
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        run: terraform init -input=false -no-color
+
+      - name: Terraform Destroy
+        id: destroy
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        run: terraform destroy -auto-approve -input=false -no-color
+
+      - name: Update comment
+        if: ${{ always() }}
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+          body: |
+            ${{ format('### {0} Terraform Private Active/Active Destruction Report', job.status == 'success' && ':white_check_mark:' || ':x:') }}
 
             ${{ format(':link: [Action Summary Page]({0})', steps.vars.outputs.run-url) }}
 

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -185,3 +185,212 @@ jobs:
             ${{ format('- {0} Run k6 Smoke Test', steps.run-smoke-test.outcome == 'success' && ':white_check_mark:' || ':x:') }}
 
             ${{ github.event.client_payload.slash_command.args.named.destroy != 'false' && format('- {0} Terraform Destroy', steps.destroy.outcome == 'success' && ':white_check_mark:' || ':x:') || '' }}
+
+  private_active_active:
+    name: Run tf-test on Private Active/Active
+    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'private-active-active') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      WORK_DIR_PATH: ./tests/private-active-active
+      K6_WORK_DIR_PATH: ./tests/tfe-load-test
+    steps:
+      - name: Create URL to the run output
+        id: vars
+        run: echo ::set-output name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+
+      # Checkout the branch of the pull request being tested
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.client_payload.pull_request.head.sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
+
+      # Checkout the hashicorp/tfe-load-test repository
+      - name: Checkout TFE Load Test
+        uses: actions/checkout@v2
+        with:
+          ref: 'master'
+          path: ${{ env.K6_WORK_DIR_PATH }}
+          repository: hashicorp/tfe-load-test
+          token: ${{ secrets.GH_TFE_LOAD_TEST_TOKEN }}
+          persist-credentials: false
+
+      - name: Install required tools
+        working-directory: ${{ env.K6_WORK_DIR_PATH }}
+        env:
+          K6_URL: https://github.com/loadimpact/k6/releases/download/v0.31.1/k6-v0.31.1-linux64.tar.gz
+        run: |
+          sudo apt-get install jq
+          curl -L $K6_URL | tar -xz --strip-components=1
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v1
+        with:
+          cli_config_credentials_hostname: 'app.terraform.io'
+          cli_config_credentials_token: ${{ secrets.PRIVATE_ACTIVE_ACTIVE_TFC_TOKEN }}
+          terraform_version: 0.14.8
+          terraform_wrapper: true
+
+      # Run Terraform commands between these comments vvv
+
+      - name: Terraform Init
+        id: init
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        run: terraform init -input=false -no-color
+
+      - name: Terraform Validate
+        id: validate
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        run: terraform validate -no-color
+
+      - name: Write GitHub Actions runner CIDR to Terraform Variables
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        run: |
+          echo "iact_subnet_list = [\"$( dig +short @resolver1.opendns.com myip.opendns.com )/32\"]" > github.auto.tfvars
+
+      - name: Terraform Apply
+        id: apply
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        run: terraform apply -auto-approve -input=false -no-color
+
+      - name: Retrieve Health Check URL
+        id: retrieve-health-check-url
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        run: |
+          terraform output -no-color -raw health_check_url
+
+      - name: Retrieve Instance Name
+        id: retrieve-instance-name
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        run: |
+          terraform output -no-color -raw proxy_instance_name
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v0.2.1
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          export_default_credentials: true
+
+      - name: Start SOCKS5 Proxy
+        env:
+          INSTANCE_NAME: ${{ steps.retrieve-instance-id.outputs.stdout }}
+        run: |
+          gcloud compute ssh \
+          --tunnel-through-iap \
+          --zone="$INSTANCE_ZONE" \
+          "$INSTANCE_NAME" \
+          -- -N -p 22 -D localhost:5000
+
+      - name: Wait For TFE
+        id: wait-for-tfe
+        timeout-minutes: 15
+        env:
+          HEALTH_CHECK_URL: ${{ steps.retrieve-health-check-url.outputs.stdout }}
+        run: |
+          echo "Curling \`health_check_url\` for a return status of 200..."
+          while ! curl \
+            -sfS --max-time 5 --proxy socks5://localhost:5000 \
+            $HEALTH_CHECK_URL; \
+            do sleep 5; done
+
+      - name: Retrieve TFE URL
+        id: retrieve-tfe-url
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        run: |
+          terraform output -no-color -raw tfe_url
+
+      - name: Retrieve IACT URL
+        id: retrieve-iact-url
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        run: |
+          terraform output -no-color -raw iact_url
+
+      - name: Retrieve IACT
+        id: retrieve-iact
+        env:
+          IACT_URL: ${{ steps.retrieve-iact-url.outputs.stdout }}
+        run: |
+          echo "::set-output name=token::$( \
+            curl --fail --retry 5 --verbose --proxy socks5://localhost:5000 "$IACT_URL" )"
+
+      - name: Retrieve Initial Admin User URL
+        id: retrieve-initial-admin-user-url
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        run: |
+          terraform output -no-color -raw initial_admin_user_url
+
+      - name: Create Admin in TFE
+        id: create-admin
+        env:
+          TFE_PASSWORD: ${{ secrets.TFE_PASSWORD }}
+          IAU_URL: ${{ steps.retrieve-initial-admin-user-url.outputs.stdout }}
+          IACT_TOKEN: ${{ steps.retrieve-iact.outputs.token }}
+        run: |
+          echo \
+            '{"username": "test", "email": "tf-onprem-team@hashicorp.com", "password": "$TFE_PASSWORD"}' \
+            > ./payload.json
+          echo "::set-output name=response::$( \
+            curl \
+            --fail \
+            --retry 5 \
+            --verbose \
+            --header 'Content-Type: application/json' \
+            --data @./payload.json \
+            --proxy socks5://localhost:5000 \
+            "$IAU_URL"?token="$IACT_TOKEN")"
+
+      - name: Retrieve Admin Token
+        id: retrieve-admin-token
+        env:
+          RESPONSE: ${{ steps.create-admin.outputs.response }}
+        run: |
+          echo "::set-output name=token::$(echo "$RESPONSE" | jq --raw-output '.token')"
+
+      - name: Run k6 Smoke Test
+        id: run-smoke-test
+        working-directory: ${{ env.K6_WORK_DIR_PATH }}
+        env:
+          K6_PATHNAME: "./k6"
+          TFE_URL: "${{ steps.retrieve-tfe-url.outputs.stdout }}"
+          TFE_API_TOKEN: "${{ steps.retrieve-admin-token.outputs.token }}"
+          TFE_EMAIL: tf-onprem-team@hashicorp.com
+          http_proxy: socks5://localhost:5000/
+          https_proxy: socks5://localhost:5000/
+        run: |
+          make smoke-test
+
+      - name: Terraform Destroy
+        id: destroy
+        if: ${{ always() && github.event.client_payload.slash_command.args.named.destroy != 'false' }}
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        run: terraform destroy -auto-approve -input=false -no-color
+
+      # Run Terraform commands between these comments ^^^
+
+      - name: Update comment
+        if: ${{ always() }}
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+          body: |
+            ${{ format('### {0} Terraform Private Active/Active Test Report', job.status == 'success' && ':white_check_mark:' || ':x:') }}
+
+            ${{ format(':link: [Action Summary Page]({0})', steps.vars.outputs.run-url) }}
+
+            ${{ format('- {0} Terraform Init', steps.init.outcome == 'success' && ':white_check_mark:' || ':x:') }}
+
+            ${{ format('- {0} Terraform Validate', steps.validate.outcome == 'success' && ':white_check_mark:' || ':x:') }}
+
+            ${{ format('- {0} Terraform Apply', steps.apply.outcome == 'success' && ':white_check_mark:' || ':x:') }}
+
+            ${{ format('- {0} Run k6 Smoke Test', steps.run-smoke-test.outcome == 'success' && ':white_check_mark:' || ':x:') }}
+
+            ${{ github.event.client_payload.slash_command.args.named.destroy != 'false' && format('- {0} Terraform Destroy', steps.destroy.outcome == 'success' && ':white_check_mark:' || ':x:') || '' }}


### PR DESCRIPTION
## Background

This branch adds support for `/test private-active-active`, based on the AWS module system. Notable differences include:
- the use of the setup-gcloud action to configure cloud credentials, rather than the configure-aws-credentials action
- the use of the gcloud CLI to create the SOCKS5 proxy, rather than the aws CLI.

## How Has This Been Tested

This will be tested in a subsequent PR that implements the test configuration.

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media1.giphy.com/media/QvwCVnX9DWdlHCnix5/200w.gif?cid=5a38a5a2xm7iez84z4m815zuxykf4qu98684nqt4f32j8r8d&rid=200w.gif&ct=g)
