### PR TITLE
Fix reference to retrieve-instance-name

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -279,7 +279,7 @@ jobs:
 
       - name: Start SOCKS5 Proxy
         env:
-          INSTANCE_NAME: ${{ steps.retrieve-instance-id.outputs.stdout }}
+          INSTANCE_NAME: ${{ steps.retrieve-instance-name.outputs.stdout }}
         run: |
           gcloud compute ssh \
           --tunnel-through-iap \


### PR DESCRIPTION
## Background

This branch fixes a reference to `steps.retrieve-instance-name` in the private-active-active test handler.


## How Has This Been Tested

This will be tested in #89.

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media2.giphy.com/media/9PqOegBqgBnMHvERV3/giphy.gif?cid=5a38a5a2cgyjlci72g75x663lg0pnq4t8dqomd005a2ne0ad&rid=giphy.gif&ct=g)
