### PR TITLE
Retrieve instance zone; noninteractive gcloud

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -270,6 +270,12 @@ jobs:
         run: |
           terraform output -no-color -raw proxy_instance_name
 
+      - name: Retrieve Instance Zone
+        id: retrieve-instance-zone
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        run: |
+          terraform output -no-color -raw proxy_instance_zone
+
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v0.2.1
         with:
@@ -280,6 +286,7 @@ jobs:
       - name: Start SOCKS5 Proxy
         env:
           INSTANCE_NAME: ${{ steps.retrieve-instance-name.outputs.stdout }}
+          INSTANCE_ZONE: ${{ steps.retrieve-instance-zone.outputs.stdout }}
         run: |
           gcloud compute ssh \
           --tunnel-through-iap \

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -290,6 +290,7 @@ jobs:
         run: |
           gcloud compute ssh \
           --quiet \
+          --ssh-key-expire-after="1440m" \
           --tunnel-through-iap \
           --zone="$INSTANCE_ZONE" \
           "$INSTANCE_NAME" \

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -289,6 +289,7 @@ jobs:
           INSTANCE_ZONE: ${{ steps.retrieve-instance-zone.outputs.stdout }}
         run: |
           gcloud compute ssh \
+          --quiet \
           --tunnel-through-iap \
           --zone="$INSTANCE_ZONE" \
           "$INSTANCE_NAME" \


### PR DESCRIPTION
## Background

This branch retrieves the instance zone from the Terraform outputs and configures gcloud for noninteractive use.

## How Has This Been Tested

This will be tested in #89.

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media1.giphy.com/media/RlGouOhIODKDWFbJrh/200.gif?cid=5a38a5a2mlw8854n1ssc0ia2vqxjaw9xnlfyik4f8t5b2dzk&rid=200.gif&ct=g)
