### PR TITLE
Increase wait-for-tfe to 25 minutes

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -298,7 +298,7 @@ jobs:
 
       - name: Wait For TFE
         id: wait-for-tfe
-        timeout-minutes: 15
+        timeout-minutes: 25
         env:
           HEALTH_CHECK_URL: ${{ steps.retrieve-health-check-url.outputs.stdout }}
         run: |


### PR DESCRIPTION
## Background

This branch increases the wait for TFE in the private-active-active test to 25 minutes, to account for the very slow installation time on RHEL.


## How Has This Been Tested

This will be tested in #89.

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media4.giphy.com/media/ohdmJuMIE08Ld7Jj0s/200.gif?cid=5a38a5a2oeewrr5bk2z8xd2wxo2yuygzrujkb2nrekn8vpoj&rid=200.gif&ct=g)
