### PR TITLE
Drop iact_subnet_list from private-active-active

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -248,11 +248,6 @@ jobs:
         working-directory: ${{ env.WORK_DIR_PATH }}
         run: terraform validate -no-color
 
-      - name: Write GitHub Actions runner CIDR to Terraform Variables
-        working-directory: ${{ env.WORK_DIR_PATH }}
-        run: |
-          echo "iact_subnet_list = [\"$( dig +short @resolver1.opendns.com myip.opendns.com )/32\"]" > github.auto.tfvars
-
       - name: Terraform Apply
         id: apply
         working-directory: ${{ env.WORK_DIR_PATH }}


### PR DESCRIPTION
## Background

This branch drops `iact_subnet_list` from the `private-active-active` handler as the value must be set within configuration to include only the IP address of the HTTP proxy instance.


## How Has This Been Tested

This will be tested in #89.

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media1.giphy.com/media/9qZdsxBrvcy2c/giphy.gif?cid=5a38a5a2k5193rga31n5ng47br8cz1d3c8cyz3dn0qwjt80v&rid=giphy.gif&ct=g)
