### PR TITLE
Doc updates node nums

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This module is intended to run in a GCP project with minimal preparation, howeve
 
 The SSL certificate for the TFE load balancer is a pre-requisite for this module.
 
-The certificate can be provisioned in [GCP here](https://console.cloud.google.com/net-services/loadbalancing/advanced/sslCertificates/list) either by creating a managed GCP certificate or by uploading an existing certificate.
+The certificate can be provisioned in [GCP here](https://console.cloud.google.com/net-services/loadbalancing/advanced/sslCertificates/list) either by creating a managed GCP certificate or by uploading an existing certificate. To upload your own certificate, you need to use the advanced menu to manage the load balancer resources.
 
 For more information on provisioning certificates in GCP, read the [documentation here](https://cloud.google.com/load-balancing/docs/ssl-certificates/google-managed-certs).
 

--- a/main.tf
+++ b/main.tf
@@ -39,6 +39,7 @@ module "object_storage" {
   labels       = local.labels
   license_name = var.tfe_license_name
   license_path = var.tfe_license_path
+  location     = var.gcs_location
 }
 
 resource "google_storage_bucket_object" "proxy_cert" {

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -24,7 +24,7 @@ variable "disk_size" {
   type        = number
 }
 variable "postgres_version" {
-  default     = "POSTGRES_9_6"
+  default     = "POSTGRES_12"
   description = "The version of PostgreSQL to be installed on the SQL database instance."
   type        = string
 }

--- a/modules/object_storage/variables.tf
+++ b/modules/object_storage/variables.tf
@@ -8,6 +8,12 @@ variable "labels" {
   type        = map(string)
 }
 
+variable "location" {
+  description = "Location of the GCS bucket"
+  type        = string
+  default     = "us"
+}
+
 variable "license_name" {
   description = <<-EOD
   The name that will be assigned to the Replicated license file when it is uploaded to the storage bucket.

--- a/variables.tf
+++ b/variables.tf
@@ -107,7 +107,7 @@ variable "database_availability_type" {
   type        = string
 }
 variable "database_backup_start_time" {
-  default     = "00:00"
+  default     = "02:00"
   description = "Database backup start time"
   type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -172,3 +172,9 @@ variable "ssl_certificate_name" {
   description = "Name of the created managed SSL certificate. Required when load_balancer == \"PUBLIC\" or load_balancer == \"PRIVATE\"."
   type        = string
 }
+# OBJECT STORE VARS
+variable "gcs_location" {
+  description = "Location of the bucket to act as the TFE Object Store"
+  type        = string
+  default     = "us"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -102,7 +102,7 @@ variable "database_machine_type" {
   type        = string
 }
 variable "database_availability_type" {
-  default     = "ZONAL"
+  default     = "REGIONAL"
   description = "Database Availability Type"
   type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -17,7 +17,7 @@ variable "node_count" {
   description = "Number of TFE nodes. Between 1 and 5"
   type        = number
   validation {
-    condition     = var.node_count <= 5
+    condition     = var.node_count <= 2
     error_message = "The node_count value must be less than or equal to 5."
   }
 }


### PR DESCRIPTION
## Background

Amends the version of PostgreSQL to the same which is deployed in Mounted Disk mode deployments (12), the node count to that which is currently supported, externalises the location of the GCS bucket acting as the object store and makes the database regional, not zonal in order to confer zone redundancy as per the RA.

I also added a line to the README to help readers and also aligned the standard DB backup window to later in the night to help with bank customer EOD processing which often runs until 1230-0100.

## How Has This Been Tested

I deployed a GCP instance (557) and confirmed the application started. Postgres v12 deployment is confirmed.

### Test Configuration

* Terraform Version: 202108-1
* Any additional relevant variables: 
  * node_count           = 1
  * separate DV TLS public cert predeployed

## This PR makes me feel

![hopeful I'm not wasting engineering time](https://media.giphy.com/media/1eChSPFlFeaAzsoB9v/giphy.gif)
