### PR TITLE
Add SSH options to private-tcp-active-active SOCKS5 proxy

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -502,7 +502,10 @@ jobs:
           --tunnel-through-iap \
           --zone="$INSTANCE_ZONE" \
           "$INSTANCE_NAME" \
-          -- -f -N -p 22 -D localhost:5000
+          -- \
+          -o 'ServerAliveInterval 5' \
+          -o 'ServerAliveCountMax 3' \
+          -f -N -p 22 -D localhost:5000
 
       - name: Wait For TFE
         id: wait-for-tfe


### PR DESCRIPTION
## Background

This branch adds the `ServerAliveInterval` and `ServerAliveCountMax` options to the SSH command of the SOCKS5 proxy in the private-tcp-active-active test job, similiar to what is used in the AWS module. This will hopefully address the failure to get a connection acknowledgement.




## How Has This Been Tested

To be tested in #96.

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media0.giphy.com/media/gjCXhIH6dzR4m9Ox27/giphy.gif?cid=5a38a5a2oa3d4hgcnqgz2ova5syfy6unacb1iypaw6yimr2r&rid=giphy.gif&ct=g)
