### PR TITLE
use vars for set-output values so that they fail

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -110,8 +110,8 @@ jobs:
         env:
           IACT_URL: ${{ steps.retrieve-iact-url.outputs.stdout }}
         run: |
-          echo "::set-output name=token::$( \
-            curl --fail --retry 5 --verbose "$IACT_URL" )"
+          token=$(curl --fail --retry 5 --verbose "$IACT_URL")
+          echo "::set-output name=token::$token"
 
       - name: Retrieve Initial Admin User URL
         id: retrieve-initial-admin-user-url
@@ -129,21 +129,23 @@ jobs:
           echo \
             '{"username": "test", "email": "tf-onprem-team@hashicorp.com", "password": "$TFE_PASSWORD"}' \
             > ./payload.json
-          echo "::set-output name=response::$( \
+          response=$( \
             curl \
             --fail \
             --retry 5 \
             --verbose \
             --header 'Content-Type: application/json' \
             --data @./payload.json \
-            "$IAU_URL"?token="$IACT")"
+            "$IAU_URL"?token="$IACT")
+          echo "::set-output name=response::$response"
 
       - name: Retrieve Admin Token
         id: retrieve-admin-token
         env:
           RESPONSE: ${{ steps.create-admin.outputs.response }}
         run: |
-          echo "::set-output name=token::$(echo "$RESPONSE" | jq --raw-output '.token')"
+          token=$(echo "$RESPONSE" | jq --raw-output '.token')
+          echo "::set-output name=token::$token"
 
       - name: Run k6 Smoke Test
         id: run-smoke-test
@@ -320,8 +322,8 @@ jobs:
         env:
           IACT_URL: ${{ steps.retrieve-iact-url.outputs.stdout }}
         run: |
-          echo "::set-output name=token::$( \
-            curl --fail --retry 5 --verbose --proxy socks5://localhost:5000 "$IACT_URL" )"
+          token=$(curl --fail --retry 5 --verbose --proxy socks5://localhost:5000 "$IACT_URL")
+          echo "::set-output name=token::$token"
 
       - name: Retrieve Initial Admin User URL
         id: retrieve-initial-admin-user-url
@@ -339,7 +341,7 @@ jobs:
           echo \
             '{"username": "test", "email": "tf-onprem-team@hashicorp.com", "password": "$TFE_PASSWORD"}' \
             > ./payload.json
-          echo "::set-output name=response::$( \
+          response=$( \
             curl \
             --fail \
             --retry 5 \
@@ -347,14 +349,16 @@ jobs:
             --header 'Content-Type: application/json' \
             --data @./payload.json \
             --proxy socks5://localhost:5000 \
-            "$IAU_URL"?token="$IACT_TOKEN")"
+            "$IAU_URL"?token="$IACT_TOKEN")
+          echo "::set-output name=response::$response"
 
       - name: Retrieve Admin Token
         id: retrieve-admin-token
         env:
           RESPONSE: ${{ steps.create-admin.outputs.response }}
         run: |
-          echo "::set-output name=token::$(echo "$RESPONSE" | jq --raw-output '.token')"
+          token=$(echo "$RESPONSE" | jq --raw-output '.token')
+          echo "::set-output name=token::$token"
 
       - name: Run k6 Smoke Test
         id: run-smoke-test
@@ -536,8 +540,8 @@ jobs:
         env:
           IACT_URL: ${{ steps.retrieve-iact-url.outputs.stdout }}
         run: |
-          echo "::set-output name=token::$( \
-            curl --fail --retry 5 --verbose --proxy socks5://localhost:5000 "$IACT_URL" )"
+          token=$(curl --fail --retry 5 --verbose --proxy socks5://localhost:5000 "$IACT_URL")
+          echo "::set-output name=token::$token"
 
       - name: Retrieve Initial Admin User URL
         id: retrieve-initial-admin-user-url
@@ -555,7 +559,7 @@ jobs:
           echo \
             '{"username": "test", "email": "tf-onprem-team@hashicorp.com", "password": "$TFE_PASSWORD"}' \
             > ./payload.json
-          echo "::set-output name=response::$( \
+          response=$( \
             curl \
             --fail \
             --retry 5 \
@@ -563,14 +567,16 @@ jobs:
             --header 'Content-Type: application/json' \
             --data @./payload.json \
             --proxy socks5://localhost:5000 \
-            "$IAU_URL"?token="$IACT_TOKEN")"
+            "$IAU_URL"?token="$IACT_TOKEN")
+          echo "::set-output name=response::$response"
 
       - name: Retrieve Admin Token
         id: retrieve-admin-token
         env:
           RESPONSE: ${{ steps.create-admin.outputs.response }}
         run: |
-          echo "::set-output name=token::$(echo "$RESPONSE" | jq --raw-output '.token')"
+          token=$(echo "$RESPONSE" | jq --raw-output '.token')
+          echo "::set-output name=token::token"
 
       - name: Run k6 Smoke Test
         id: run-smoke-test


### PR DESCRIPTION
## Background

Currently, if a `::set-output` command sets a value to be the output of a `curl` command that fails, the value is set to an empty string. This branch changes it so that the `curl` output is stored in a variable first, and then the `::set-output` command uses the variable. This way, if `curl` fails, the build will fail.

[Asana Task](https://app.asana.com/0/1181500399442529/1200819228490425/f)

## How Has This Been Tested

I used a poc repo and first ran the existing logic [here](https://github.com/anniehedgpeth/hello-world-composite-run-steps-action/runs/3691375331?check_suite_focus=true#step:5:1), which does not fail (reproducing the problem).
I added the variable logic [to this build](https://github.com/anniehedgpeth/hello-world-composite-run-steps-action/runs/3691354714?check_suite_focus=true#step:5:1), and it failed, as desired.

## This PR makes me feel

![bob dylan fail sign](https://media.giphy.com/media/li0dswKqIZNpm/giphy.gif)
