### PR TITLE
test

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -576,7 +576,7 @@ jobs:
           RESPONSE: ${{ steps.create-admin.outputs.response }}
         run: |
           token=$(echo "$RESPONSE" | jq --raw-output '.token')
-          echo "::set-output name=token::token"
+          echo "::set-output name=token::$token"
 
       - name: Run k6 Smoke Test
         id: run-smoke-test


### PR DESCRIPTION
## Background

This was just want to test the previous merge of #104 of changes to the workflow, but the test found that we're missing a necessary `$`. This adds it back.

[Asana Task](https://app.asana.com/0/1181500399442529/1200819228490425/f)

