### PR TITLE
Update Standalone Mounted Disk resource names

### DIFF
--- a/tests/standalone-mounted-disk/data.tf
+++ b/tests/standalone-mounted-disk/data.tf
@@ -1,5 +1,5 @@
 data "google_dns_managed_zone" "main" {
-  name = "ptfe-replicated"
+  name = "public"
 }
 
 data "google_compute_image" "ubuntu" {

--- a/tests/standalone-mounted-disk/main.tf
+++ b/tests/standalone-mounted-disk/main.tf
@@ -24,7 +24,7 @@ module "tfe" {
   namespace            = random_pet.main.id
   node_count           = 1
   license_secret       = google_secret_manager_secret.license.secret_id
-  ssl_certificate_name = "ptfe-replicated-wildcard"
+  ssl_certificate_name = "wildcard"
 
   iact_subnet_list       = var.iact_subnet_list
   iact_subnet_time_limit = 60


### PR DESCRIPTION
## Background

This branch updates the hard-coded resource names in the standalone-mounted-disk test based on the correct GCP project.


Relates https://github.com/hashicorp/ptfedev-infra/pull/273


## How Has This Been Tested

It will be tested through the CI flow.

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media1.giphy.com/media/3o6Mbfal2sHCGhZEHe/giphy.gif?cid=5a38a5a26nkixiwpahdigdlh2ekjz9omuartebt07lso0tgc&rid=giphy.gif&ct=g)
