### PR TITLE
Standalone Mounted Disk IACT permissive subnet list

### DIFF
--- a/tests/standalone-mounted-disk/main.tf
+++ b/tests/standalone-mounted-disk/main.tf
@@ -26,7 +26,7 @@ module "tfe" {
   license_secret       = google_secret_manager_secret.license.secret_id
   ssl_certificate_name = "wildcard"
 
-  iact_subnet_list       = var.iact_subnet_list
+  iact_subnet_list       = ["0.0.0.0/0"]
   iact_subnet_time_limit = 60
   labels = {
     department  = "engineering"

--- a/tests/standalone-mounted-disk/variables.tf
+++ b/tests/standalone-mounted-disk/variables.tf
@@ -1,12 +1,3 @@
-variable "iact_subnet_list" {
-  default     = []
-  description = <<-EOD
-  A list of IP address ranges which will be authorized to access the IACT. The ranges must be expressed
-  in CIDR notation.
-  EOD
-  type        = list(string)
-}
-
 variable "license_file" {
   type        = string
   description = "The local path to the Terraform Enterprise license to be provided by CI."


### PR DESCRIPTION
## Background

This branch allows `0.0.0.0/0` to access the IACT in the Standalone Mounted Disk test.



## This PR makes me feel

![optional gif describing your feelings about this pr](https://media2.giphy.com/media/KczqttEJqm55hE1ccU/200.gif?cid=5a38a5a2ghqk93fhosn25z105znrkj24z6wv8ggkkdnxuq6b&rid=200.gif&ct=g)
