### PR TITLE
Enable SSH debugging on SES test

### DIFF
--- a/tests/standalone-external-services/data.tf
+++ b/tests/standalone-external-services/data.tf
@@ -7,3 +7,23 @@ data "google_compute_image" "ubuntu" {
 
   project = "ubuntu-os-cloud"
 }
+
+data "google_compute_region_instance_group" "tfe" {
+  self_link = null_resource.wait_for_instances.triggers.self_link
+}
+
+data "google_compute_instance" "tfe" {
+  self_link = data.google_compute_region_instance_group.tfe.instances[0].instance
+}
+
+# This null_data_source is used to prevent Terraform from trying to render local_file.ssh_config file before data.
+# google_compute_instance.tfe is available.
+# See https://github.com/hashicorp/terraform-provider-local/issues/57
+data "null_data_source" "instance" {
+  inputs = {
+    name       = data.google_compute_instance.tfe.name
+    network_ip = data.google_compute_instance.tfe.network_interface[0].network_ip
+    project    = data.google_compute_instance.tfe.project
+    zone       = data.google_compute_instance.tfe.zone
+  }
+}

--- a/tests/standalone-external-services/locals.tf
+++ b/tests/standalone-external-services/locals.tf
@@ -1,4 +1,5 @@
 locals {
   repository_location = "us-west1"
   repository_name     = "terraform-build-worker"
+  ssh_user            = "ubuntu"
 }

--- a/tests/standalone-external-services/outputs.tf
+++ b/tests/standalone-external-services/outputs.tf
@@ -17,3 +17,15 @@ output "ptfe_health_check" {
   value       = module.tfe.health_check_url
   description = "Terraform Enterprise Health Check URL"
 }
+
+output "ssh_config_file" {
+  value = local_file.ssh_config.filename
+
+  description = "The pathname of the SSH configuration file that grants access to the compute instance."
+}
+
+output "ssh_private_key" {
+  value = local_file.private_key_pem.filename
+
+  description = "The pathname of the private SSH key."
+}

--- a/tests/standalone-external-services/templates/ssh-config.tpl
+++ b/tests/standalone-external-services/templates/ssh-config.tpl
@@ -1,0 +1,11 @@
+Host default
+    HostName ${instance.network_ip}
+    User ${user}
+    Port 22
+    UserKnownHostsFile /dev/null
+    StrictHostKeyChecking no
+    PasswordAuthentication no
+    IdentityFile ${identity_file}
+    IdentitiesOnly yes
+    LogLevel FATAL
+    ProxyCommand gcloud compute start-iap-tunnel ${instance.name} 22 --listen-on-stdin --verbosity=warning --project=${instance.project} --zone=${instance.zone}

--- a/tests/standalone-external-services/versions.tf
+++ b/tests/standalone-external-services/versions.tf
@@ -12,9 +12,24 @@ terraform {
       version = "~> 3.54"
     }
 
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.1"
+    }
+
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.1"
+    }
+
     random = {
       source  = "hashicorp/random"
       version = "~> 3.0"
+    }
+
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 3.1"
     }
   }
 }


### PR DESCRIPTION
## Background

This branch adds the necessary logic to the Standalone External Services test to facilitate SSH connections from the CI environment.


[Asana task](https://app.asana.com/0/1181500399442529/1201068889880706/f)


## How Has This Been Tested

I provisioned the test and confirmed that the SSH connection worked.

### Test Configuration

* Terraform Version: 1.0.9

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media4.giphy.com/media/3o6MbtoyGQ7eBMPegw/giphy.gif?cid=5a38a5a224nmmqa7cx9fvz264xzb0vt0rya8whrtbiea6qbl&rid=giphy.gif&ct=g)
