### PR TITLE
Update module source and configure providers

### DIFF
--- a/.github/workflows/handler-destroy.yml
+++ b/.github/workflows/handler-destroy.yml
@@ -74,9 +74,10 @@ jobs:
           TFE_TOKEN: ${{ secrets.TFE_TOKEN }}
           TFE_WORKSPACE: ${{ secrets.TFE_WORKSPACE }}
         run: |
+          echo "$GOOGLE_CREDENTIALS" > google-credentials.json
           cat <<EOF > github.auto.tfvars
           google = {
-            credentials = "$GOOGLE_CREDENTIALS"
+            credentials = "google-credentials.json"
             project     = "$GOOGLE_PROJECT"
             region      = "$GOOGLE_REGION"
             zone        = "$GOOGLE_ZONE"

--- a/.github/workflows/handler-destroy.yml
+++ b/.github/workflows/handler-destroy.yml
@@ -29,6 +29,13 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           persist-credentials: false
 
+      - name: Set Terraform Module Source
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        env:
+          REPO_FULL_NAME: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
+          REF: ${{ github.event.client_payload.pull_request.head.sha }}
+        run: sed --in-place='s/source = "..\/.."/source = "github.com\/$REPO_FULL_NAME?ref=$REF"/' main.tf
+
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v1
         with:

--- a/.github/workflows/handler-destroy.yml
+++ b/.github/workflows/handler-destroy.yml
@@ -65,20 +65,33 @@ jobs:
       - name: Write Terraform Variables
         working-directory: ${{ env.WORK_DIR_PATH }}
         env:
+          GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
+          GOOGLE_PROJECT: ${{ secrets.GOOGLE_PROJECT }}
+          GOOGLE_REGION: ${{ secrets.GOOGLE_REGION }}
+          GOOGLE_ZONE: ${{ secrets.GOOGLE_ZONE }}
+          TFE_HOSTNAME: ${{ secrets.TFE_HOSTNAME }}
           TFE_ORGANIZATION: ${{ secrets.TFE_ORGANIZATION }}
+          TFE_TOKEN: ${{ secrets.TFE_TOKEN }}
           TFE_WORKSPACE: ${{ secrets.TFE_WORKSPACE }}
         run: |
           cat <<EOF > github.auto.tfvars
-          tfe_organization = "$TFE_ORGANIZATION"
-          tfe_workspace = "$TFE_WORKSPACE"
+          google = {
+            credentials = "$GOOGLE_CREDENTIALS"
+            project     = "$GOOGLE_PROJECT"
+            region      = "$GOOGLE_REGION"
+            zone        = "$GOOGLE_ZONE"
+          }
+          tfe = {
+            hostname     = "$TFE_HOSTNAME"
+            organization = "$TFE_ORGANIZATION"
+            token        = "$TFE_TOKEN"
+            workspace    = "$TFE_WORKSPACE"
+          }
           EOF
 
       - name: Terraform Destroy
         id: destroy
         working-directory: ${{ env.WORK_DIR_PATH }}
-        env:
-          TFE_HOSTNAME: ${{ secrets.TFE_HOSTNAME }}
-          TFE_TOKEN: ${{ secrets.TFE_TOKEN }}
         run: terraform destroy -auto-approve -input=false -no-color
 
       - name: Update comment

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -91,22 +91,35 @@ jobs:
       - name: Write Terraform Variables
         working-directory: ${{ env.WORK_DIR_PATH }}
         env:
+          GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
+          GOOGLE_PROJECT: ${{ secrets.GOOGLE_PROJECT }}
+          GOOGLE_REGION: ${{ secrets.GOOGLE_REGION }}
+          GOOGLE_ZONE: ${{ secrets.GOOGLE_ZONE }}
+          TFE_HOSTNAME: ${{ secrets.TFE_HOSTNAME }}
           TFE_ORGANIZATION: ${{ secrets.TFE_ORGANIZATION }}
+          TFE_TOKEN: ${{ secrets.TFE_TOKEN }}
           TFE_WORKSPACE: ${{ secrets.TFE_WORKSPACE }}
         run: |
           ip_address=$( dig +short @resolver1.opendns.com myip.opendns.com )
           cat <<EOF > github.auto.tfvars
           iact_subnet_list = ["$ip_address/32"]
-          tfe_organization = "$TFE_ORGANIZATION"
-          tfe_workspace = "$TFE_WORKSPACE"
+          google = {
+            credentials = "$GOOGLE_CREDENTIALS"
+            project     = "$GOOGLE_PROJECT"
+            region      = "$GOOGLE_REGION"
+            zone        = "$GOOGLE_ZONE"
+          }
+          tfe = {
+            hostname     = "$TFE_HOSTNAME"
+            organization = "$TFE_ORGANIZATION"
+            token        = "$TFE_TOKEN"
+            workspace    = "$TFE_WORKSPACE"
+          }
           EOF
 
       - name: Terraform Apply
         id: apply
         working-directory: ${{ env.WORK_DIR_PATH }}
-        env:
-          TFE_HOSTNAME: ${{ secrets.TFE_HOSTNAME }}
-          TFE_TOKEN: ${{ secrets.TFE_TOKEN }}
         run: terraform apply -auto-approve -input=false -no-color
 
       - name: Retrieve Health Check URL

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -101,10 +101,11 @@ jobs:
           TFE_WORKSPACE: ${{ secrets.TFE_WORKSPACE }}
         run: |
           ip_address=$( dig +short @resolver1.opendns.com myip.opendns.com )
+          echo "$GOOGLE_CREDENTIALS" > google-credentials.json
           cat <<EOF > github.auto.tfvars
           iact_subnet_list = ["$ip_address/32"]
           google = {
-            credentials = "$GOOGLE_CREDENTIALS"
+            credentials = "google-credentials.json"
             project     = "$GOOGLE_PROJECT"
             region      = "$GOOGLE_REGION"
             zone        = "$GOOGLE_ZONE"

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -30,6 +30,13 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           persist-credentials: false
 
+      - name: Set Terraform Module Source
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        env:
+          REPO_FULL_NAME: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
+          REF: ${{ github.event.client_payload.pull_request.head.sha }}
+        run: sed --in-place='s/source = "..\/.."/source = "github.com\/$REPO_FULL_NAME?ref=$REF"/' main.tf
+
       # Checkout the hashicorp/tfe-load-test repository
       - name: Checkout TFE Load Test
         uses: actions/checkout@v2


### PR DESCRIPTION
## Background

This branch has 2 fixes.

First, it dynamically updates the TFE module source from a local pathname to a GitHub reference to the same repository and commit. This is necessary because the transient workspaces have no working directory, which means only the local working directory is uploaded to TFC and the required root module is omitted.

Second, it configures the tfe and google providers using Terraform variables as environment variables are not propagated from GHA to TFC.

## How Has This Been Tested

This will be tested in #120.

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media3.giphy.com/media/l1OlIcFVAL2xBR1HM7/200w.gif?cid=5a38a5a2adnuqaj6t3g8jwqust8cjnykpf1o0ptwc9w9hkut&rid=200w.gif&ct=g)
