### PR TITLE
Fix Google Credentials in PAA test

### DIFF
--- a/.github/workflows/handler-destroy.yml
+++ b/.github/workflows/handler-destroy.yml
@@ -75,10 +75,11 @@ jobs:
           TFE_TOKEN: ${{ secrets.TFE_TOKEN }}
           TFE_WORKSPACE: ${{ secrets.TFE_WORKSPACE }}
         run: |
-          echo "$GOOGLE_CREDENTIALS" > google-credentials.json
           cat <<EOF > github.auto.tfvars
           google = {
-            credentials = "google-credentials.json"
+            credentials = <<-EOC
+            $GOOGLE_CREDENTIALS
+            EOC
             project     = "$GOOGLE_PROJECT"
             region      = "$GOOGLE_REGION"
             zone        = "$GOOGLE_ZONE"

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -102,11 +102,12 @@ jobs:
           TFE_WORKSPACE: ${{ secrets.TFE_WORKSPACE }}
         run: |
           ip_address=$( dig +short @resolver1.opendns.com myip.opendns.com )
-          echo "$GOOGLE_CREDENTIALS" > google-credentials.json
           cat <<EOF > github.auto.tfvars
           iact_subnet_list = ["$ip_address/32"]
           google = {
-            credentials = "google-credentials.json"
+            credentials = <<-EOC
+            $GOOGLE_CREDENTIALS
+            EOC
             project     = "$GOOGLE_PROJECT"
             region      = "$GOOGLE_REGION"
             zone        = "$GOOGLE_ZONE"


### PR DESCRIPTION
## Background

This branch updates the github.auto.tfvars files for the Public Active/Active test to directly include the contents of GOOGLE_CREDENTIALS by using heredocs. This avoids the HCL escaping issue caused by the value's JSON content.

Relates #122


## How Has This Been Tested

In #120.

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media1.giphy.com/media/XBiHIKDIrSfp44oEXO/200w.gif?cid=5a38a5a2yc1g5zgorep9cn1zmhglv9i2ggfu6jrzcrj9387u&rid=200w.gif&ct=g)
