### PR TITLE
Use consistent types on both conditional paths

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -25,9 +25,8 @@ locals {
   full_fqdn = "${local.common_fqdn}."
 
   private_load_balancing_enabled = length(google_compute_address.private) > 0
-  lb_address = (
-    local.private_load_balancing_enabled ? google_compute_address.private : google_compute_global_address.public
-  )[0].address
+  lb_address                     = local.private_load_balancing_enabled ? google_compute_address.private[0].address : google_compute_global_address.public[0].address
+
   trusted_proxies = local.private_load_balancing_enabled ? compact([
     "${local.lb_address}/32",
     # Include IP address range of the reserve subnetwork for private load balancing


### PR DESCRIPTION
## Background

This change should fix the following error:

```
 Error: Inconsistent conditional result types
 
   on ../../locals.tf line 29, in locals:
   29:     local.private_load_balancing_enabled ? google_compute_address.private : google_compute_global_address.public
     ├────────────────
     │ google_compute_address.private is a list of object, known only after apply
     │ google_compute_global_address.public is a list of object, known only after apply
     │ local.private_load_balancing_enabled is a bool, known only after apply
 
 The true and false result expressions must have consistent types. The given expressions are list of object and list of object, respectively.
```

## How Has This Been Tested

Used the module to spin up a Terraform Enterprise installation that was previously failing.

### Test Configuration

N/A

## This PR makes me feel

N/A