### PR TITLE
Replace Windows line endings

### DIFF
--- a/modules/user_data/locals.tf
+++ b/modules/user_data/locals.tf
@@ -232,44 +232,48 @@ locals {
 
   repl_configs = jsonencode(merge(local.replicated_base_config, local.is_airgap, local.is_pinned, local.tls))
 
-  user_data = templatefile(
-    "${path.module}/templates/tfe_vm.sh.tpl",
-    {
-      airgap_pathname          = local.airgap_pathname
-      airgap_url               = var.airgap_url
-      ca_certificate_secret    = var.ca_certificate_secret
-      custom_image_tag         = var.custom_image_tag
-      disk_device_name         = var.disk_device_name
-      disk_path                = var.enable_disk ? var.disk_path : null
-      docker_config            = filebase64("${path.module}/files/daemon.json")
-      bucket_name              = var.gcs_bucket
-      lib_directory            = local.lib_directory
-      license_file_location    = local.license_file_location
-      license_secret           = var.license_secret
-      monitoring_enabled       = var.monitoring_enabled
-      replicated               = base64encode(local.repl_configs)
-      settings                 = base64encode(local.settings)
-      enable_active_active     = var.enable_active_active
-      namespace                = var.namespace
-      proxy_ip                 = var.proxy_ip
-      settings_pathname        = local.settings_pathname
-      ssl_certificate_pathname = local.ssl_certificate_pathname
-      ssl_certificate_secret   = var.ssl_certificate_secret
-      ssl_private_key_pathname = local.ssl_private_key_pathname
-      ssl_private_key_secret   = var.ssl_private_key_secret
-      no_proxy = join(
-        ",",
-        concat(
-          [
-            "127.0.0.1",
-            "169.254.169.254",
-            ".googleapis.com",
-            ".google.internal",
-            ".googlecloud.com",
-          ],
-          var.no_proxy
+  user_data = replace(
+    templatefile(
+      "${path.module}/templates/tfe_vm.sh.tpl",
+      {
+        airgap_pathname          = local.airgap_pathname
+        airgap_url               = var.airgap_url
+        ca_certificate_secret    = var.ca_certificate_secret
+        custom_image_tag         = var.custom_image_tag
+        disk_device_name         = var.disk_device_name
+        disk_path                = var.enable_disk ? var.disk_path : null
+        docker_config            = filebase64("${path.module}/files/daemon.json")
+        bucket_name              = var.gcs_bucket
+        lib_directory            = local.lib_directory
+        license_file_location    = local.license_file_location
+        license_secret           = var.license_secret
+        monitoring_enabled       = var.monitoring_enabled
+        replicated               = base64encode(local.repl_configs)
+        settings                 = base64encode(local.settings)
+        enable_active_active     = var.enable_active_active
+        namespace                = var.namespace
+        proxy_ip                 = var.proxy_ip
+        settings_pathname        = local.settings_pathname
+        ssl_certificate_pathname = local.ssl_certificate_pathname
+        ssl_certificate_secret   = var.ssl_certificate_secret
+        ssl_private_key_pathname = local.ssl_private_key_pathname
+        ssl_private_key_secret   = var.ssl_private_key_secret
+        no_proxy = join(
+          ",",
+          concat(
+            [
+              "127.0.0.1",
+              "169.254.169.254",
+              ".googleapis.com",
+              ".google.internal",
+              ".googlecloud.com",
+            ],
+            var.no_proxy
+          )
         )
-      )
-    }
+      }
+    ),
+    "\r\n",
+    "\n"
   )
 }

--- a/tests/private-active-active/main.tf
+++ b/tests/private-active-active/main.tf
@@ -63,11 +63,15 @@ resource "google_compute_instance" "http_proxy" {
   name         = local.name
 
   description = "An HTTP proxy for TFE."
-  metadata_startup_script = templatefile(
-    "${path.module}/templates/startup.sh.tpl",
-    {
-      http_proxy_port = local.http_proxy_port
-    }
+  metadata_startup_script = replace(
+    templatefile(
+      "${path.module}/templates/startup.sh.tpl",
+      {
+        http_proxy_port = local.http_proxy_port
+      }
+    ),
+    "\r\n",
+    "\n"
   )
 
   network_interface {

--- a/tests/private-tcp-active-active/main.tf
+++ b/tests/private-tcp-active-active/main.tf
@@ -75,13 +75,17 @@ resource "google_compute_instance" "http_proxy" {
   name         = local.name
 
   description = "An HTTP proxy for TFE."
-  metadata_startup_script = templatefile(
-    "${path.module}/templates/startup.sh.tpl",
-    {
-      certificate_secret_id = data.tfe_outputs.base.values.ca_certificate_secret_id
-      http_proxy_port       = local.http_proxy_port
-      private_key_secret_id = data.tfe_outputs.base.values.ca_private_key_secret_id
-    }
+  metadata_startup_script = replace(
+    templatefile(
+      "${path.module}/templates/startup.sh.tpl",
+      {
+        certificate_secret_id = data.tfe_outputs.base.values.ca_certificate_secret_id
+        http_proxy_port       = local.http_proxy_port
+        private_key_secret_id = data.tfe_outputs.base.values.ca_private_key_secret_id
+      }
+    ),
+    "\r\n",
+    "\n"
   )
 
   network_interface {

--- a/tests/standalone-external-rhel8-worker/main.tf
+++ b/tests/standalone-external-rhel8-worker/main.tf
@@ -81,12 +81,16 @@ resource "null_resource" "wait_for_instances" {
 resource "local_file" "ssh_config" {
   filename = "${path.module}/work/ssh-config"
 
-  content = templatefile(
-    "${path.module}/templates/ssh-config.tpl",
-    {
-      instance      = data.null_data_source.instance.outputs
-      identity_file = local_file.private_key_pem.filename
-      user          = local.ssh_user
-    }
+  content = replace(
+    templatefile(
+      "${path.module}/templates/ssh-config.tpl",
+      {
+        instance      = data.null_data_source.instance.outputs
+        identity_file = local_file.private_key_pem.filename
+        user          = local.ssh_user
+      }
+    ),
+    "\r\n",
+    "\n"
   )
 }

--- a/tests/standalone-mounted-disk/main.tf
+++ b/tests/standalone-mounted-disk/main.tf
@@ -64,12 +64,16 @@ resource "null_resource" "wait_for_instances" {
 resource "local_file" "ssh_config" {
   filename = "${path.module}/work/ssh-config"
 
-  content = templatefile(
-    "${path.module}/templates/ssh-config.tpl",
-    {
-      instance      = data.null_data_source.instance.outputs
-      identity_file = local_file.private_key_pem.filename
-      user          = local.ssh_user
-    }
+  content = replace(
+    templatefile(
+      "${path.module}/templates/ssh-config.tpl",
+      {
+        instance      = data.null_data_source.instance.outputs
+        identity_file = local_file.private_key_pem.filename
+        user          = local.ssh_user
+      }
+    ),
+    "\r\n",
+    "\n"
   )
 }


### PR DESCRIPTION
## Background

This PR wraps each call to `templatefile` with a call to `replace` that replaces any Windows line endings (`\r\n`) with Unix line endings. This should work around invalid line endings being introduced if Terraform is executed in a Windows environment.


Closes #172


## How Has This Been Tested

The module tests will be run here, in addition to manual testing in #127.


## This PR makes me feel

![optional gif describing your feelings about this pr](https://media4.giphy.com/media/KlrMS4vyq5KSY/giphy.gif?cid=5a38a5a2ob17lbx523gsq8bniurif04dt72rhjmm89xshb4s&rid=giphy.gif&ct=g)
