### PR TITLE
Add var.vm_mounted_disk_size

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -158,7 +158,7 @@ module "vm_instance_template" {
       device_name  = local.disk_device_name
       disk_labels  = var.labels
       disk_name    = "${var.namespace}-tfe-mounted"
-      disk_size_gb = 40
+      disk_size_gb = var.vm_mounted_disk_size
       disk_type    = "pd-ssd"
       mode         = "READ_WRITE"
     }

--- a/variables.tf
+++ b/variables.tf
@@ -204,6 +204,14 @@ variable "vm_metadata" {
   type        = map(string)
 }
 
+variable "vm_mounted_disk_size" {
+  default     = 40
+  description = <<-EOD
+  The size in gigabytes of the mounted disk to attach to the VM when the Operational Mode is Mounted Disk.
+  EOD
+  type        = number
+}
+
 # USER DATA / TFE
 # ---------------
 variable "release_sequence" {


### PR DESCRIPTION
## Background

This PR adds a variable to control the size of the mounted disk used in Mounted Disk mode.


Asana task: https://app.asana.com/0/1181500399442529/1201474260744977/f


## How Has This Been Tested

We will only rely on the Terraform validity check as this is a simple refactor from a hard-coded value to a variable with an equivalent default value.

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media2.giphy.com/media/3o6Mb7xQofFu2PTPFe/giphy.gif?cid=5a38a5a2xbmt4cb5oui1f6lw4jd60hcb0g4mhcx7jjtgg82w&rid=giphy.gif&ct=g)
