### PR TITLE
Finish initial implemenation of airgap support

### DIFF
--- a/modules/user_data/templates/tfe_vm.sh.tpl
+++ b/modules/user_data/templates/tfe_vm.sh.tpl
@@ -225,6 +225,7 @@ curl --create-dirs --output $install_pathname $install_url
 %{ endif ~}
 echo "[Terraform Enterprise] Executing Replicated installation script at '$install_pathname'" | tee -a $log_pathname
 chmod +x $install_pathname
+cd $replicated_directory
 $install_pathname \
   fast-timeouts \
   private-address="$private_ip" \

--- a/modules/user_data/templates/tfe_vm.sh.tpl
+++ b/modules/user_data/templates/tfe_vm.sh.tpl
@@ -189,7 +189,7 @@ echo "[Terraform Enterprise] Extracting Replicated in '$replicated_directory'" |
 tar --directory $replicated_directory --extract --file $replicated_pathname
 
 echo "[Terraform Enterprise] Copying airgap storage object '${airgap_url}' to '${airgap_pathname}'" | tee -a $log_pathname
-http_proxy="" https_proxy="" gsutil cp ${airgap_url} ${airgap_pathname}
+curl --create-dirs --output ${airgap_pathname} ${airgap_url}
 
 %{ else ~}
 install_url="https://get.replicated.com/docker/terraformenterprise/active-active"

--- a/modules/user_data/templates/tfe_vm.sh.tpl
+++ b/modules/user_data/templates/tfe_vm.sh.tpl
@@ -182,10 +182,11 @@ install_pathname="$replicated_directory/install.sh"
 %{ if airgap_url != null ~}
 replicated_filename="replicated.tar.gz"
 replicated_url="https://s3.amazonaws.com/replicated-airgap-work/$replicated_filename"
-echo "[Terraform Enterprise] Downloading Replicated from '$replicated_url' to '$replicated_directory'" | tee -a $log_pathname
-curl --create-dirs --output $replicated_directory/$replicated_filename $replicated_url
+replicated_pathname="$replicated_directory/$replicated_filename"
+echo "[Terraform Enterprise] Downloading Replicated from '$replicated_url' to '$replicated_pathname'" | tee -a $log_pathname
+curl --create-dirs --output $replicated_pathname $replicated_url
 echo "[Terraform Enterprise] Extracting Replicated in '$replicated_directory'" | tee -a $log_pathname
-tar --directory $replicated_directory --extract --file $replicated_filename
+tar --directory $replicated_directory --extract --file $replicated_pathname
 
 echo "[Terraform Enterprise] Copying airgap storage object '${airgap_url}' to '${airgap_pathname}'" | tee -a $log_pathname
 http_proxy="" https_proxy="" gsutil cp ${airgap_url} ${airgap_pathname}

--- a/modules/user_data/templates/tfe_vm.sh.tpl
+++ b/modules/user_data/templates/tfe_vm.sh.tpl
@@ -184,12 +184,12 @@ replicated_filename="replicated.tar.gz"
 replicated_url="https://s3.amazonaws.com/replicated-airgap-work/$replicated_filename"
 replicated_pathname="$replicated_directory/$replicated_filename"
 echo "[Terraform Enterprise] Downloading Replicated from '$replicated_url' to '$replicated_pathname'" | tee -a $log_pathname
-curl --create-dirs --output $replicated_pathname $replicated_url
+curl --create-dirs --output "$replicated_pathname" "$replicated_url"
 echo "[Terraform Enterprise] Extracting Replicated in '$replicated_directory'" | tee -a $log_pathname
-tar --directory $replicated_directory --extract --file $replicated_pathname
+tar --directory "$replicated_directory" --extract --file "$replicated_pathname"
 
-echo "[Terraform Enterprise] Copying airgap storage object '${airgap_url}' to '${airgap_pathname}'" | tee -a $log_pathname
-curl --create-dirs --output ${airgap_pathname} ${airgap_url}
+echo "[Terraform Enterprise] Copying airgap package '${airgap_url}' to '${airgap_pathname}'" | tee -a $log_pathname
+curl --create-dirs --output "${airgap_pathname}" "${airgap_url}"
 
 %{ else ~}
 install_url="https://get.replicated.com/docker/terraformenterprise/active-active"

--- a/modules/user_data/templates/tfe_vm.sh.tpl
+++ b/modules/user_data/templates/tfe_vm.sh.tpl
@@ -179,13 +179,11 @@ private_ip=$(curl -H "Metadata-Flavor: Google" "http://169.254.169.254/computeMe
 
 replicated_directory="/tmp/replicated"
 install_pathname="$replicated_directory/install.sh"
-mkdir --parents $replicated_directory
-
 %{ if airgap_url != null ~}
 replicated_filename="replicated.tar.gz"
 replicated_url="https://s3.amazonaws.com/replicated-airgap-work/$replicated_filename"
 echo "[Terraform Enterprise] Downloading Replicated from '$replicated_url' to '$replicated_directory'" | tee -a $log_pathname
-curl --remote-name --output-dir $replicated_directory $replicated_url
+curl --create-dirs --output $replicated_directory/$replicated_filename $replicated_url
 echo "[Terraform Enterprise] Extracting Replicated in '$replicated_directory'" | tee -a $log_pathname
 tar --directory $replicated_directory --extract --file $replicated_filename
 
@@ -195,7 +193,7 @@ http_proxy="" https_proxy="" gsutil cp ${airgap_url} ${airgap_pathname}
 %{ else ~}
 install_url="https://get.replicated.com/docker/terraformenterprise/active-active"
 echo "[Terraform Enterprise] Downloading Replicated installation script from '$install_url' to '$install_pathname'" | tee -a $log_pathname
-curl --output $install_pathname $install_url
+curl --create-dirs --output $install_pathname $install_url
 
 %{ endif ~}
 echo "[Terraform Enterprise] Executing Replicated installation script at '$install_pathname'" | tee -a $log_pathname

--- a/modules/user_data/variables.tf
+++ b/modules/user_data/variables.tf
@@ -211,7 +211,7 @@ variable "redis_use_tls" {
 # Replicated Configs
 # ------------------
 variable "airgap_url" {
-  description = "The URL of the storage bucket object that comprises an airgap package."
+  description = "The URL of a Replicated airgap package for Terraform Enterprise."
   type        = string
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -222,7 +222,7 @@ variable "release_sequence" {
 
 variable "airgap_url" {
   default     = null
-  description = "The URL of the storage bucket object that comprises an airgap package."
+  description = "The URL of a Replicated airgap package for Terraform Enterprise."
   type        = string
 }
 


### PR DESCRIPTION
## Background

This PR finishes the initial implementation of airgap support.

Some assumptions that will need to be revisited when this use case is better understood:

- `airgap_url` is expected to be an HTTPS URL for an airgap package, like the ones provided by the Replicated vendor portal.
- Docker can be installed by package manager
  - Replicated [states](https://community.replicated.com/t/installing-docker-in-airgapped-environments/81) most customers use repository mirrors
- Ubuntu deployments can reach download.docker.com to obtain the Docker GPG key

Asana task: https://app.asana.com/0/1181500399442529/1201475371010432/f


## How Has This Been Tested

Successfully deployed an airgap package using our internal development workflow.

## This PR makes me feel

![optional gif describing your feelings about this pr]()
