### PR TITLE
Optional service account

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -29,12 +29,12 @@ module "object_storage" {
 module "service_accounts" {
   source = "./modules/service_accounts"
 
-  ca_certificate_secret  = var.ca_certificate_secret
-  license_secret         = var.license_secret
-  namespace              = var.namespace
-  ssl_certificate_secret = var.ssl_certificate_secret
-  ssl_private_key_secret = var.ssl_private_key_secret
-
+  ca_certificate_secret       = var.ca_certificate_secret
+  license_secret              = var.license_secret
+  namespace                   = var.namespace
+  ssl_certificate_secret      = var.ssl_certificate_secret
+  ssl_private_key_secret      = var.ssl_private_key_secret
+  override_service_account_id = var.override_service_account_id
   depends_on = [
     module.project_factory_project_services
   ]
@@ -54,7 +54,6 @@ module "networking" {
   service_account      = module.service_accounts.service_account
   ip_allow_list        = var.networking_ip_allow_list
   ssh_source_ranges    = var.ssh_source_ranges
-
   depends_on = [
     module.project_factory_project_services
   ]

--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ module "service_accounts" {
   namespace                   = var.namespace
   ssl_certificate_secret      = var.ssl_certificate_secret
   ssl_private_key_secret      = var.ssl_private_key_secret
-  override_service_account_id = var.override_service_account_id
+  existing_service_account_id = var.existing_service_account_id
   depends_on = [
     module.project_factory_project_services
   ]

--- a/modules/service_accounts/locals.tf
+++ b/modules/service_accounts/locals.tf
@@ -1,5 +1,5 @@
 locals {
   service_account = var.override_service_account_id == null ? google_service_account.main[0] : data.google_service_account.main[0]
 
-  member = "serviceAccount:${local.service_account.main.email}"
+  member = "serviceAccount:${local.service_account.email}"
 }

--- a/modules/service_accounts/locals.tf
+++ b/modules/service_accounts/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  service_account = var.override_service_account_id == null ? google_service_account.main[0] : data.google_service_account.main[0]
+  service_account = var.existing_service_account_id == null ? google_service_account.main[0] : data.google_service_account.main[0]
 
   member = "serviceAccount:${local.service_account.email}"
 }

--- a/modules/service_accounts/locals.tf
+++ b/modules/service_accounts/locals.tf
@@ -1,3 +1,5 @@
 locals {
-  member = "serviceAccount:${google_service_account.main.email}"
+  service_account = var.override_service_account_id == null ? google_service_account.main[0] : data.google_service_account.main[0]
+
+  member = "serviceAccount:${local.service_account.main.email}"
 }

--- a/modules/service_accounts/main.tf
+++ b/modules/service_accounts/main.tf
@@ -1,5 +1,5 @@
 resource "random_id" "account" {
-  count = var.override_service_account_id == null ? 1 : 0
+  count = var.existing_service_account_id == null ? 1 : 0
   # 30 bytes ensures that enough characters are generated to satisfy the service account ID requirements, regardless of
   # the prefix.
   byte_length = 30
@@ -7,7 +7,7 @@ resource "random_id" "account" {
 }
 
 resource "google_service_account" "main" {
-  count = var.override_service_account_id == null ? 1 : 0
+  count = var.existing_service_account_id == null ? 1 : 0
   # Limit the string used to 30 characters.
   account_id   = substr(random_id.account[count.index].dec, 0, 30)
   display_name = "TFE"
@@ -15,8 +15,8 @@ resource "google_service_account" "main" {
 }
 
 data "google_service_account" "main" {
-  count      = var.override_service_account_id == null ? 0 : 1
-  account_id = var.override_service_account_id
+  count      = var.existing_service_account_id == null ? 0 : 1
+  account_id = var.existing_service_account_id
 }
 
 resource "google_service_account_key" "key" {
@@ -24,7 +24,7 @@ resource "google_service_account_key" "key" {
 }
 
 resource "google_project_iam_member" "log_writer" {
-  count  = var.override_service_account_id == null ? 1 : 0
+  count  = var.existing_service_account_id == null ? 1 : 0
   member = local.member
   role   = "roles/logging.logWriter"
 }

--- a/modules/service_accounts/main.tf
+++ b/modules/service_accounts/main.tf
@@ -20,7 +20,6 @@ data "google_service_account" "main" {
 }
 
 resource "google_service_account_key" "key" {
-  count              = 1
   service_account_id = local.service_account.name
 }
 

--- a/modules/service_accounts/main.tf
+++ b/modules/service_accounts/main.tf
@@ -21,7 +21,7 @@ data "google_service_account" "main" {
 
 resource "google_service_account_key" "key" {
   count              = 1
-  service_account_id = var.override_service_account_id != null ? google_service_account.main[count.index].name : data.google_service_account.main[count.index].name
+  service_account_id = local.service_account.name
 }
 
 resource "google_project_iam_member" "log_writer" {

--- a/modules/service_accounts/main.tf
+++ b/modules/service_accounts/main.tf
@@ -1,4 +1,5 @@
 resource "random_id" "account" {
+  count = var.override_service_account_id == null ? 1 : 0
   # 30 bytes ensures that enough characters are generated to satisfy the service account ID requirements, regardless of
   # the prefix.
   byte_length = 30
@@ -6,17 +7,25 @@ resource "random_id" "account" {
 }
 
 resource "google_service_account" "main" {
+  count = var.override_service_account_id == null ? 1 : 0
   # Limit the string used to 30 characters.
-  account_id   = substr(random_id.account.dec, 0, 30)
+  account_id   = substr(random_id.account[count.index].dec, 0, 30)
   display_name = "TFE"
   description  = "Service Account used by Terraform Enterprise."
 }
 
+data "google_service_account" "main" {
+  count      = var.override_service_account_id == null ? 0 : 1
+  account_id = var.override_service_account_id
+}
+
 resource "google_service_account_key" "key" {
-  service_account_id = google_service_account.main.name
+  count              = 1
+  service_account_id = var.override_service_account_id != null ? google_service_account.main[count.index].name : data.google_service_account.main[count.index].name
 }
 
 resource "google_project_iam_member" "log_writer" {
+  count  = var.override_service_account_id == null ? 1 : 0
   member = local.member
   role   = "roles/logging.logWriter"
 }

--- a/modules/service_accounts/outputs.tf
+++ b/modules/service_accounts/outputs.tf
@@ -1,5 +1,5 @@
 output "credentials" {
-  value = base64decode(google_service_account_key.key[0].private_key)
+  value = base64decode(google_service_account_key.key.private_key)
 
   description = "The private key of the service account."
 }

--- a/modules/service_accounts/outputs.tf
+++ b/modules/service_accounts/outputs.tf
@@ -1,10 +1,10 @@
 output "credentials" {
-  value = base64decode(google_service_account_key.key.private_key)
+  value = base64decode(google_service_account_key.key[0].private_key)
 
   description = "The private key of the service account."
 }
 output "service_account" {
-  value = google_service_account.main
+  value = var.override_service_account_id == null ? google_service_account.main[0] : data.google_service_account.main[0]
 
   description = "The service account."
 }

--- a/modules/service_accounts/outputs.tf
+++ b/modules/service_accounts/outputs.tf
@@ -4,7 +4,7 @@ output "credentials" {
   description = "The private key of the service account."
 }
 output "service_account" {
-  value = var.override_service_account_id == null ? google_service_account.main[0] : data.google_service_account.main[0]
+  value = var.existing_service_account_id == null ? google_service_account.main[0] : data.google_service_account.main[0]
 
   description = "The service account."
 }

--- a/modules/service_accounts/variables.tf
+++ b/modules/service_accounts/variables.tf
@@ -35,10 +35,10 @@ variable "ssl_private_key_secret" {
   type        = string
 }
 
-variable "override_service_account_id" {
+variable "existing_service_account_id" {
   description = <<-EOD
-  An ID of a service account to use for log management. Setting this value prevents terraform from creating a new user and
-  assigning  a logWriter IAM role.
+  An ID of an existing service account to use for log management. Setting this value prevents terraform from creating
+  a new user and assigning  a logWriter IAM role.
   EOD
   type        = string
   default     = null

--- a/modules/service_accounts/variables.tf
+++ b/modules/service_accounts/variables.tf
@@ -37,7 +37,7 @@ variable "ssl_private_key_secret" {
 
 variable "override_service_account_id" {
   description = <<-EOD
-  A ID of a service account to use for log management. Setting this value prevents terraform from creating a new user and
+  An ID of a service account to use for log management. Setting this value prevents terraform from creating a new user and
   assigning  a logWriter IAM role.
   EOD
   type        = string

--- a/modules/service_accounts/variables.tf
+++ b/modules/service_accounts/variables.tf
@@ -34,3 +34,12 @@ variable "ssl_private_key_secret" {
   EOD
   type        = string
 }
+
+variable "override_service_account_id" {
+  description = <<-EOD
+  A ID of a service account to use for log management. Setting this value prevents terraform from creating a new user and
+  assigning  a logWriter IAM role.
+  EOD
+  type        = string
+  default     = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -53,6 +53,15 @@ variable "labels" {
   default     = {}
 }
 
+variable "override_service_account_id" {
+  description = <<-EOD
+  An ID of a service account to use for log management. Setting this value prevents terraform from creating a new user and
+  assigning  a logWriter IAM role.
+  EOD
+  type        = string
+  default     = null
+}
+
 # NETWORKING
 # -----------
 variable "networking_firewall_ports" {

--- a/variables.tf
+++ b/variables.tf
@@ -53,10 +53,10 @@ variable "labels" {
   default     = {}
 }
 
-variable "override_service_account_id" {
+variable "existing_service_account_id" {
   description = <<-EOD
-  An ID of a service account to use for log management. Setting this value prevents terraform from creating a new user and
-  assigning  a logWriter IAM role.
+  An ID of an existing service account to use for log management. Setting this value prevents terraform from creating
+  a new user and assigning  a logWriter IAM role.
   EOD
   type        = string
   default     = null


### PR DESCRIPTION
## Background

This change adds an optional variable, override_service_account_id, that prevents terraform from creating a new service account for logging purposes and instead uses the provided service account. This impacts the identity used for logging from the firewall and compute cloud objects. When a service account id is provided a data block is used to pull the account data and is transparently passed to the output of the service account sub-module.

## How Has This Been Tested

This branch was used to generate an operational TFE instance in a GCP project with IAM management disallowed. This TFE instance was fully operational and applied completely.  GCP tests will be executed on this pull request to handle negative testing.

### Test Configuration

* Terraform Version: 1.0.11
* Any additional relevant variables: NA

## This PR makes me feel

<img src="https://media1.giphy.com/media/Y3l2CbTxVd6oC47Bq5/giphy.gif"/>
