### PR TITLE
GCP testing project move changes

### DIFF
--- a/.github/workflows/handler-destroy.yml
+++ b/.github/workflows/handler-destroy.yml
@@ -71,6 +71,7 @@ jobs:
           GOOGLE_PROJECT: ${{ secrets.GOOGLE_PROJECT }}
           GOOGLE_REGION: ${{ secrets.GOOGLE_REGION }}
           GOOGLE_ZONE: ${{ secrets.GOOGLE_ZONE }}
+          GOOGLE_SERVICE_ACCOUNT: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
           TFE_HOSTNAME: ${{ secrets.TFE_HOSTNAME }}
           TFE_ORGANIZATION: ${{ secrets.TFE_ORGANIZATION }}
           TFE_TOKEN: ${{ secrets.TFE_TOKEN }}
@@ -78,12 +79,13 @@ jobs:
         run: |
           cat <<EOF > github.auto.tfvars
           google = {
-            credentials = <<-EOC
+            credentials     = <<-EOC
             $GOOGLE_CREDENTIALS
             EOC
-            project     = "$GOOGLE_PROJECT"
-            region      = "$GOOGLE_REGION"
-            zone        = "$GOOGLE_ZONE"
+            project         = "$GOOGLE_PROJECT"
+            region          = "$GOOGLE_REGION"
+            zone            = "$GOOGLE_ZONE"
+            service_account = "$GOOGLE_SERVICE_ACCOUNT"
           }
           tfe = {
             hostname     = "$TFE_HOSTNAME"
@@ -179,6 +181,7 @@ jobs:
           GOOGLE_PROJECT: ${{ secrets.GOOGLE_PROJECT }}
           GOOGLE_REGION: ${{ secrets.GOOGLE_REGION }}
           GOOGLE_ZONE: ${{ secrets.GOOGLE_ZONE }}
+          GOOGLE_SERVICE_ACCOUNT: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
           TFE_HOSTNAME: ${{ secrets.TFE_HOSTNAME }}
           TFE_ORGANIZATION: ${{ secrets.TFE_ORGANIZATION }}
           TFE_TOKEN: ${{ secrets.TFE_TOKEN }}
@@ -186,12 +189,13 @@ jobs:
         run: |
           cat <<EOF > github.auto.tfvars
           google = {
-            credentials = <<-EOC
+            credentials     = <<-EOC
             $GOOGLE_CREDENTIALS
             EOC
-            project     = "$GOOGLE_PROJECT"
-            region      = "$GOOGLE_REGION"
-            zone        = "$GOOGLE_ZONE"
+            project         = "$GOOGLE_PROJECT"
+            region          = "$GOOGLE_REGION"
+            zone            = "$GOOGLE_ZONE"
+            service_account = "$GOOGLE_SERVICE_ACCOUNT"
           }
           tfe = {
             hostname     = "$TFE_HOSTNAME"
@@ -288,6 +292,7 @@ jobs:
           GOOGLE_PROJECT: ${{ secrets.GOOGLE_PROJECT }}
           GOOGLE_REGION: ${{ secrets.GOOGLE_REGION }}
           GOOGLE_ZONE: ${{ secrets.GOOGLE_ZONE }}
+          GOOGLE_SERVICE_ACCOUNT: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
           TFE_HOSTNAME: ${{ secrets.TFE_HOSTNAME }}
           TFE_ORGANIZATION: ${{ secrets.TFE_ORGANIZATION }}
           TFE_TOKEN: ${{ secrets.TFE_TOKEN }}
@@ -295,12 +300,13 @@ jobs:
         run: |
           cat <<EOF > github.auto.tfvars
           google = {
-            credentials = <<-EOC
+            credentials     = <<-EOC
             $GOOGLE_CREDENTIALS
             EOC
-            project     = "$GOOGLE_PROJECT"
-            region      = "$GOOGLE_REGION"
-            zone        = "$GOOGLE_ZONE"
+            project         = "$GOOGLE_PROJECT"
+            region          = "$GOOGLE_REGION"
+            zone            = "$GOOGLE_ZONE"
+            service_account = "$GOOGLE_SERVICE_ACCOUNT"
           }
           tfe = {
             hostname     = "$TFE_HOSTNAME"

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -94,6 +94,7 @@ jobs:
           GOOGLE_PROJECT: ${{ secrets.GOOGLE_PROJECT }}
           GOOGLE_REGION: ${{ secrets.GOOGLE_REGION }}
           GOOGLE_ZONE: ${{ secrets.GOOGLE_ZONE }}
+          GOOGLE_SERVICE_ACCOUNT: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
           TFE_HOSTNAME: ${{ secrets.TFE_HOSTNAME }}
           TFE_ORGANIZATION: ${{ secrets.TFE_ORGANIZATION }}
           TFE_TOKEN: ${{ secrets.TFE_TOKEN }}
@@ -103,12 +104,13 @@ jobs:
           cat <<EOF > github.auto.tfvars
           iact_subnet_list = ["$ip_address/32"]
           google = {
-            credentials = <<-EOC
+            credentials     = <<-EOC
             $GOOGLE_CREDENTIALS
             EOC
-            project     = "$GOOGLE_PROJECT"
-            region      = "$GOOGLE_REGION"
-            zone        = "$GOOGLE_ZONE"
+            project         = "$GOOGLE_PROJECT"
+            region          = "$GOOGLE_REGION"
+            zone            = "$GOOGLE_ZONE"
+            service_account = "$GOOGLE_SERVICE_ACCOUNT"
           }
           tfe = {
             hostname     = "$TFE_HOSTNAME"
@@ -322,6 +324,7 @@ jobs:
           GOOGLE_PROJECT: ${{ secrets.GOOGLE_PROJECT }}
           GOOGLE_REGION: ${{ secrets.GOOGLE_REGION }}
           GOOGLE_ZONE: ${{ secrets.GOOGLE_ZONE }}
+          GOOGLE_SERVICE_ACCOUNT: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
           TFE_HOSTNAME: ${{ secrets.TFE_HOSTNAME }}
           TFE_ORGANIZATION: ${{ secrets.TFE_ORGANIZATION }}
           TFE_TOKEN: ${{ secrets.TFE_TOKEN }}
@@ -329,12 +332,13 @@ jobs:
         run: |
           cat <<EOF > github.auto.tfvars
           google = {
-            credentials = <<-EOC
+            credentials     = <<-EOC
             $GOOGLE_CREDENTIALS
             EOC
-            project     = "$GOOGLE_PROJECT"
-            region      = "$GOOGLE_REGION"
-            zone        = "$GOOGLE_ZONE"
+            project         = "$GOOGLE_PROJECT"
+            region          = "$GOOGLE_REGION"
+            zone            = "$GOOGLE_ZONE"
+            service_account = "$GOOGLE_SERVICE_ACCOUNT"
           }
           tfe = {
             hostname     = "$TFE_HOSTNAME"
@@ -583,6 +587,7 @@ jobs:
           GOOGLE_PROJECT: ${{ secrets.GOOGLE_PROJECT }}
           GOOGLE_REGION: ${{ secrets.GOOGLE_REGION }}
           GOOGLE_ZONE: ${{ secrets.GOOGLE_ZONE }}
+          GOOGLE_SERVICE_ACCOUNT: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
           TFE_HOSTNAME: ${{ secrets.TFE_HOSTNAME }}
           TFE_ORGANIZATION: ${{ secrets.TFE_ORGANIZATION }}
           TFE_TOKEN: ${{ secrets.TFE_TOKEN }}
@@ -590,12 +595,13 @@ jobs:
         run: |
           cat <<EOF > github.auto.tfvars
           google = {
-            credentials = <<-EOC
+            credentials     = <<-EOC
             $GOOGLE_CREDENTIALS
             EOC
-            project     = "$GOOGLE_PROJECT"
-            region      = "$GOOGLE_REGION"
-            zone        = "$GOOGLE_ZONE"
+            project         = "$GOOGLE_PROJECT"
+            region          = "$GOOGLE_REGION"
+            zone            = "$GOOGLE_ZONE"
+            service_account = "$GOOGLE_SERVICE_ACCOUNT"
           }
           tfe = {
             hostname     = "$TFE_HOSTNAME"

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ This module is intended to run in a GCP project with minimal preparation, howeve
 1. Create a Cloud DNS zone for the DNS name you wish to use.
 2. Create a managed SSL Certificate in Network Services -> Load Balancing to serve as the certificate for the FQDN.
 
+Optionally a pre-existing service account may be specified with the `existing_service_account_id` variable to circumvent the need to manage IAM permissions within the module.
+
 ### Provisioning the SSL certificate
 
 The SSL certificate for the TFE load balancer is a pre-requisite for this module.

--- a/tests/private-active-active/main.tf
+++ b/tests/private-active-active/main.tf
@@ -18,13 +18,14 @@ module "test_proxy" {
 module "tfe" {
   source = "../.."
 
-  dns_zone_name        = data.google_dns_managed_zone.main.name
-  fqdn                 = "private-active-active.${data.google_dns_managed_zone.main.dns_name}"
-  namespace            = random_pet.main.id
-  node_count           = 2
-  license_secret       = data.tfe_outputs.base.values.license_secret_id
-  ssl_certificate_name = data.tfe_outputs.base.values.wildcard_region_ssl_certificate_name
-  labels               = local.labels
+  dns_zone_name               = data.google_dns_managed_zone.main.name
+  fqdn                        = "private-active-active.${data.google_dns_managed_zone.main.dns_name}"
+  namespace                   = random_pet.main.id
+  existing_service_account_id = var.google.service_account
+  node_count                  = 2
+  license_secret              = data.tfe_outputs.base.values.license_secret_id
+  ssl_certificate_name        = data.tfe_outputs.base.values.wildcard_region_ssl_certificate_name
+  labels                      = local.labels
 
   iact_subnet_list         = ["${module.test_proxy.compute_instance.network_interface[0].network_ip}/32"]
   iact_subnet_time_limit   = 1440

--- a/tests/private-active-active/variables.tf
+++ b/tests/private-active-active/variables.tf
@@ -1,10 +1,11 @@
 variable "google" {
   description = "Attributes of the Google Cloud account which will host the test infrastructure."
   type = object({
-    credentials = string
-    project     = string
-    region      = string
-    zone        = string
+    credentials     = string
+    project         = string
+    region          = string
+    zone            = string
+    service_account = string
   })
 }
 

--- a/tests/private-tcp-active-active/main.tf
+++ b/tests/private-tcp-active-active/main.tf
@@ -20,12 +20,13 @@ module "test_proxy" {
 module "tfe" {
   source = "../.."
 
-  dns_zone_name  = data.google_dns_managed_zone.main.name
-  fqdn           = "private-tcp-active-active.${data.google_dns_managed_zone.main.dns_name}"
-  namespace      = random_pet.main.id
-  node_count     = 2
-  license_secret = data.tfe_outputs.base.values.license_secret_id
-  labels         = local.labels
+  dns_zone_name               = data.google_dns_managed_zone.main.name
+  fqdn                        = "private-tcp-active-active.${data.google_dns_managed_zone.main.dns_name}"
+  namespace                   = random_pet.main.id
+  existing_service_account_id = var.google.service_account
+  node_count                  = 2
+  license_secret              = data.tfe_outputs.base.values.license_secret_id
+  labels                      = local.labels
 
   ca_certificate_secret    = data.tfe_outputs.base.values.ca_certificate_secret_id
   iact_subnet_list         = ["${module.test_proxy.compute_instance.network_interface[0].network_ip}/32"]

--- a/tests/private-tcp-active-active/variables.tf
+++ b/tests/private-tcp-active-active/variables.tf
@@ -1,10 +1,11 @@
 variable "google" {
   description = "Attributes of the Google Cloud account which will host the test infrastructure."
   type = object({
-    credentials = string
-    project     = string
-    region      = string
-    zone        = string
+    credentials     = string
+    project         = string
+    region          = string
+    zone            = string
+    service_account = string
   })
 }
 

--- a/tests/public-active-active/main.tf
+++ b/tests/public-active-active/main.tf
@@ -7,12 +7,13 @@ resource "random_pet" "main" {
 module "tfe" {
   source = "../.."
 
-  dns_zone_name        = data.google_dns_managed_zone.main.name
-  fqdn                 = "public-active-active.${data.google_dns_managed_zone.main.dns_name}"
-  namespace            = random_pet.main.id
-  node_count           = 2
-  license_secret       = data.tfe_outputs.base.values.license_secret_id
-  ssl_certificate_name = data.tfe_outputs.base.values.wildcard_ssl_certificate_name
+  dns_zone_name               = data.google_dns_managed_zone.main.name
+  fqdn                        = "public-active-active.${data.google_dns_managed_zone.main.dns_name}"
+  namespace                   = random_pet.main.id
+  existing_service_account_id = var.google.service_account
+  node_count                  = 2
+  license_secret              = data.tfe_outputs.base.values.license_secret_id
+  ssl_certificate_name        = data.tfe_outputs.base.values.wildcard_ssl_certificate_name
 
   iact_subnet_list       = var.iact_subnet_list
   iact_subnet_time_limit = 1440

--- a/tests/public-active-active/variables.tf
+++ b/tests/public-active-active/variables.tf
@@ -1,10 +1,11 @@
 variable "google" {
   description = "Attributes of the Google Cloud account which will host the test infrastructure."
   type = object({
-    credentials = string
-    project     = string
-    region      = string
-    zone        = string
+    credentials     = string
+    project         = string
+    region          = string
+    zone            = string
+    service_account = string
   })
 }
 


### PR DESCRIPTION
## Background

This change adds the existing_service_account_id variable to support a move to the new testing projects.

## How Has This Been Tested

These changes have been tested in the development environment to successful instance deployment. Testing automation on this repository will confirm the functionality in the new project. 

## This PR makes me feel

<img src="https://media1.giphy.com/media/S93ZMVEqrWsXDjBsbu/giphy.gif"/>
