### PR TITLE
Upping the wait time on TFE init

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -133,7 +133,7 @@ jobs:
 
       - name: Wait For TFE
         id: wait-for-tfe
-        timeout-minutes: 15
+        timeout-minutes: 25
         env:
           HEALTH_CHECK_URL: ${{ steps.retrieve-health-check-url.outputs.stdout }}
         run: |


### PR DESCRIPTION
## Background

Test runs are timing out on the current combination of RHEL 7 and yum cache status. This change bumps that timeout higher to give terraform enterprise the time to safely initialize.


## How Has This Been Tested

No substantive change to module code

## This PR makes me feel

<img src="https://media4.giphy.com/media/FoH28ucxZFJZu/giphy.gif"/>
