### PR TITLE
removing fast cache flag to support rhel 8

### DIFF
--- a/modules/user_data/templates/tfe_vm.sh.tpl
+++ b/modules/user_data/templates/tfe_vm.sh.tpl
@@ -27,7 +27,7 @@ then
   # workaround for GCP RHEL 7 known issue 
   # https://cloud.google.com/compute/docs/troubleshooting/known-issues#keyexpired
   sed -i 's/repo_gpgcheck=1/repo_gpgcheck=0/g' /etc/yum.repos.d/google-cloud.repo
-  yum makecache fast
+  yum makecache
 fi
 
 echo "[Terraform Enterprise] Writing Terraform Enterprise settings to '${settings_pathname}'" | tee -a $log_pathname


### PR DESCRIPTION
## Background

Removes the fast yum makecache flag to support rhel8


## How Has This Been Tested

full test suite execution
