### PR TITLE
add airgap dev example

### DIFF
--- a/examples/standalone-airgap-dev/README.md
+++ b/examples/standalone-airgap-dev/README.md
@@ -1,0 +1,56 @@
+# EXAMPLE: Standalone, Airgapped Package Installation of Terraform Enterprise (bootstrapping with airgap prerequisites)
+
+## About This Example
+
+This example for Terraform Enterprise creates a TFE installation with the following traits.
+
+- [Standalone](https://www.terraform.io/docs/enterprise/before-installing/reference-architecture/gcp.html#implementation-modes)
+- _Mocked_ Airgapped installation
+- a small VM machine type (n1-standard-4)
+- Ubuntu 20.04 as the VM image
+- a publicly accessible HTTP load balancer with TLS termination
+
+## Pre-requisites
+
+This example merely tests that the `airgap_url` package is able to install TFE. It does
+not, however, assume that the environment is air-gapped, and it therefore installs the
+prerequisites for an air-gapped installation, too. This example assumes that the following
+resources exist:
+
+- Valid DNS Zone
+- Valid managed SSL certificate
+- TFE license on a filepath accessible by tests
+- The URL of an airgap package
+
+## How to Use This Module
+
+- Read the entire README.md for the [main module](https://github.com/hashicorp/terraform-google-terraform-enterprise).
+- Ensure your Google credentials are set correctly
+- Add Google Terraform provider blocks for both the `google` and `google-beta` providers as detailed [here](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/provider_reference) to a file in this directory ending with `.tf`.
+- Create a local `terraform.auto.tfvars` file and instantiate the required inputs as listed in the next section.
+- Set the `node_count` input value to 1 to implement Standalone mode.
+- Create a Terraform configuration that pulls in this module and specifies values of the required variables:
+
+```hcl
+module "tfe_node" {
+  source                = "git@github.com:hashicorp/terraform-google-terraform-enterprise.git"
+  namespace             = "<Namespace to uniquely identify resources>"
+  node_count            = "<Number of TFE nodes to provision>"
+  tfe_license_secret_id = "<Secret Manager secret comprising license>
+  fqdn                  = "<Fully qualified domain name>"
+  ssl_certificate_name  = "<Name of the SSL certificate provisioned in GCP>"
+  dns_zone_name         = "<Name of the DNS zone in which a record set will be created>"
+  load_balancer         = "PUBLIC"  // for a publically accessible instance.  Omit this line for a private instance, or explicitly set it to "PRIVATE"
+}
+```
+
+- Run `terraform init` and `terraform apply`
+
+## Post-deployment Tasks
+
+- The build should take approximately 10-15 to deploy.  Once Terraform completes, give the platform
+another 10 minutes or so prior to attempting to interact with it in order for all containers to start up.
+- Unless amended, this example will not create an initial admin user using the IACT, but does output the
+URL for convenience. Follow the advice in [this document](https://www.terraform.io/docs/enterprise/install/automating-initial-user.html)
+in order to create the initial admin user, and login to the system using this user in order to configure
+it for use.

--- a/examples/standalone-airgap-dev/main.tf
+++ b/examples/standalone-airgap-dev/main.tf
@@ -1,0 +1,33 @@
+resource "random_pet" "main" {
+  length = 1
+}
+
+module "secrets" {
+  source = "../../fixtures/secrets"
+
+  license = {
+    id   = random_pet.main.id
+    path = var.license_file
+  }
+}
+
+module "tfe" {
+  source = "../../"
+
+  # Bootstrapping Air-gap prerequisites
+  airgap_url                                = var.airgap_url
+  tfe_license_bootstrap_airgap_package_path = "/var/lib/ptfe/ptfe.airgap"
+  tfe_license_secret_id                     = module.secrets.license_secret
+
+  # Standalone scenario  
+  distribution         = "ubuntu"
+  namespace            = var.namespace
+  node_count           = 1
+  fqdn                 = var.fqdn
+  ssl_certificate_name = var.ssl_certificate_name
+  dns_zone_name        = var.dns_zone_name
+  load_balancer        = "PUBLIC"
+
+  labels = var.labels
+
+}

--- a/examples/standalone-airgap-dev/outputs.tf
+++ b/examples/standalone-airgap-dev/outputs.tf
@@ -1,0 +1,35 @@
+output "replicated_console_password" {
+  value       = module.tfe.replicated_console_password
+  description = "Generated password for replicated dashboard"
+}
+
+output "lb_address" {
+  value       = module.tfe.lb_address
+  description = "Load Balancer Address"
+}
+
+output "health_check_url" {
+  value       = module.tfe.health_check_url
+  description = "The URL of the Terraform Enterprise health check endpoint."
+}
+
+output "iact_url" {
+  value       = module.tfe.iact_url
+  description = "IACT URL"
+}
+
+output "initial_admin_user_url" {
+  value       = module.tfe.initial_admin_user_url
+  description = "Initial Admin user URL"
+}
+
+output "url" {
+  value       = module.tfe.url
+  description = "Login URL to setup the TFE instance once it is initialized"
+}
+
+output "iact_notice" {
+  value       = "Once deployed, please follow this page to set the initial user up: https://www.terraform.io/docs/enterprise/install/automating-initial-user.html"
+  description = "Login advice message."
+}
+

--- a/examples/standalone-airgap-dev/terraform.tfvars.example
+++ b/examples/standalone-airgap-dev/terraform.tfvars.example
@@ -1,0 +1,13 @@
+namespace            = "user-friendly-name"
+fqdn                 = "tfe.my.domain.com"
+ssl_certificate_name = "certificate-name-xxxxxxxxxxxxxxxxxxxxx"
+dns_zone_name        = "my.domain.com"
+license_file         = "/files/license.rli"
+airgap_url           = "https://airgap-url/"
+
+labels = {
+  department  = "engineering"
+  description = "standalone-airgap"
+  repository  = "hashicorp-terraform-google-terraform-enterprise"
+  team        = "my-team-name"
+}

--- a/examples/standalone-airgap-dev/variables.tf
+++ b/examples/standalone-airgap-dev/variables.tf
@@ -1,0 +1,37 @@
+variable "airgap_url" {
+  description = "The URL of the storage object that comprises an airgap package."
+  type        = string
+}
+
+variable "dns_zone_name" {
+  description = "The name of the DNS zone in which a record will be created."
+  type        = string
+}
+
+variable "fqdn" {
+  description = "The fully qualified domain name which will be assigned to the DNS record."
+  type        = string
+}
+
+variable "labels" {
+  type        = map(string)
+  description = "Labels to apply to resources"
+  default     = {}
+}
+
+variable "license_file" {
+  type        = string
+  description = "The local path to the Terraform Enterprise license."
+}
+
+variable "namespace" {
+  description = "A prefix which will be applied to all resource names."
+  type        = string
+}
+
+variable "ssl_certificate_name" {
+  description = <<-EOD
+  The name of an existing SSL certificate which will be used to authenticate connections to the load balancer.
+  EOD
+  type        = string
+}

--- a/examples/standalone-airgap-dev/versions.tf
+++ b/examples/standalone-airgap-dev/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 0.14"
+  required_providers {
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}


### PR DESCRIPTION
## Background

Asana: https://app.asana.com/0/1181500399442529/1202138985475044/f

This branch adds a `standalone-airgap-dev` example which assumes that you really just want to test the airgap bundle and want to install the prereqs alongside the installation.

## How Has This Been Tested

I tested this locally and put screenshot in the [Asana task](https://app.asana.com/0/1181500399442529/1202138985475044/f).

## This PR makes me feel

![trickery](https://media.giphy.com/media/l0HU9fEnlUQ29B1II/giphy.gif)
