### PR TITLE
Making standalone test cases dynamic in their base resource config

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Checkout TFE Load Test
         uses: actions/checkout@v2
         with:
-          ref: 'main'
+          ref: 'master'
           path: ${{ env.K6_WORK_DIR_PATH }}
           repository: hashicorp/tfe-load-test
           token: ${{ secrets.GH_TFE_LOAD_TEST_TOKEN }}
@@ -272,7 +272,7 @@ jobs:
       - name: Checkout TFE Load Test
         uses: actions/checkout@v2
         with:
-          ref: 'main'
+          ref: 'master'
           path: ${{ env.K6_WORK_DIR_PATH }}
           repository: hashicorp/tfe-load-test
           token: ${{ secrets.GH_TFE_LOAD_TEST_TOKEN }}
@@ -535,7 +535,7 @@ jobs:
       - name: Checkout TFE Load Test
         uses: actions/checkout@v2
         with:
-          ref: 'main'
+          ref: 'master'
           path: ${{ env.K6_WORK_DIR_PATH }}
           repository: hashicorp/tfe-load-test
           token: ${{ secrets.GH_TFE_LOAD_TEST_TOKEN }}

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -42,7 +42,6 @@ jobs:
       - name: Checkout TFE Load Test
         uses: actions/checkout@v2
         with:
-          ref: 'master'
           path: ${{ env.K6_WORK_DIR_PATH }}
           repository: hashicorp/tfe-load-test
           token: ${{ secrets.GH_TFE_LOAD_TEST_TOKEN }}
@@ -272,7 +271,6 @@ jobs:
       - name: Checkout TFE Load Test
         uses: actions/checkout@v2
         with:
-          ref: 'master'
           path: ${{ env.K6_WORK_DIR_PATH }}
           repository: hashicorp/tfe-load-test
           token: ${{ secrets.GH_TFE_LOAD_TEST_TOKEN }}
@@ -535,7 +533,6 @@ jobs:
       - name: Checkout TFE Load Test
         uses: actions/checkout@v2
         with:
-          ref: 'master'
           path: ${{ env.K6_WORK_DIR_PATH }}
           repository: hashicorp/tfe-load-test
           token: ${{ secrets.GH_TFE_LOAD_TEST_TOKEN }}

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Checkout TFE Load Test
         uses: actions/checkout@v2
         with:
+          ref: 'main'
           path: ${{ env.K6_WORK_DIR_PATH }}
           repository: hashicorp/tfe-load-test
           token: ${{ secrets.GH_TFE_LOAD_TEST_TOKEN }}
@@ -271,6 +272,7 @@ jobs:
       - name: Checkout TFE Load Test
         uses: actions/checkout@v2
         with:
+          ref: 'main'
           path: ${{ env.K6_WORK_DIR_PATH }}
           repository: hashicorp/tfe-load-test
           token: ${{ secrets.GH_TFE_LOAD_TEST_TOKEN }}
@@ -533,6 +535,7 @@ jobs:
       - name: Checkout TFE Load Test
         uses: actions/checkout@v2
         with:
+          ref: 'main'
           path: ${{ env.K6_WORK_DIR_PATH }}
           repository: hashicorp/tfe-load-test
           token: ${{ secrets.GH_TFE_LOAD_TEST_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ backend-config.hcl
 
 # Work directories
 work
+
+# replicated license files
+*.rli

--- a/tests/private-active-active/versions.tf
+++ b/tests/private-active-active/versions.tf
@@ -19,7 +19,7 @@ terraform {
 
     tfe = {
       source  = "hashicorp/tfe"
-      version = "~> 0.26.1"
+      version = "~> 0.26"
     }
   }
 

--- a/tests/private-tcp-active-active/versions.tf
+++ b/tests/private-tcp-active-active/versions.tf
@@ -19,7 +19,7 @@ terraform {
 
     tfe = {
       source  = "hashicorp/tfe"
-      version = "~> 0.26.1"
+      version = "~> 0.26"
     }
   }
 

--- a/tests/public-active-active/versions.tf
+++ b/tests/public-active-active/versions.tf
@@ -19,7 +19,7 @@ terraform {
 
     tfe = {
       source  = "hashicorp/tfe"
-      version = "~> 0.26.1"
+      version = "~> 0.26"
     }
   }
 

--- a/tests/standalone-external-rhel8-worker/data.tf
+++ b/tests/standalone-external-rhel8-worker/data.tf
@@ -1,5 +1,10 @@
+data "tfe_outputs" "base" {
+  organization = var.tfe.organization
+  workspace    = var.tfe.workspace
+}
+
 data "google_dns_managed_zone" "main" {
-  name = "public"
+  name = data.tfe_outputs.base.values.cloud_dns_name
 }
 
 data "google_compute_image" "rhel" {

--- a/tests/standalone-external-rhel8-worker/providers.tf
+++ b/tests/standalone-external-rhel8-worker/providers.tf
@@ -1,0 +1,4 @@
+provider "tfe" {
+  hostname = var.tfe.hostname
+  token    = var.tfe.token
+}

--- a/tests/standalone-external-rhel8-worker/variables.tf
+++ b/tests/standalone-external-rhel8-worker/variables.tf
@@ -2,3 +2,18 @@ variable "license_file" {
   type        = string
   description = "The local path to the Terraform Enterprise license to be provided by CI."
 }
+
+variable "existing_service_account_id" {
+  type        = string
+  description = "The id of the logging service account to use for compute resources deployed."
+}
+
+variable "tfe" {
+  description = "Attributes of the Terraform Enterprise instance which manages the base infrastructure."
+  type = object({
+    hostname     = string
+    organization = string
+    token        = string
+    workspace    = string
+  })
+}

--- a/tests/standalone-external-rhel8-worker/versions.tf
+++ b/tests/standalone-external-rhel8-worker/versions.tf
@@ -29,7 +29,7 @@ terraform {
 
     tfe = {
       source  = "hashicorp/tfe"
-      version = "~> 0.26.1"
+      version = "~> 0.26"
     }
 
     tls = {

--- a/tests/standalone-external-rhel8-worker/versions.tf
+++ b/tests/standalone-external-rhel8-worker/versions.tf
@@ -27,6 +27,11 @@ terraform {
       version = "~> 3.0"
     }
 
+    tfe = {
+      source  = "hashicorp/tfe"
+      version = "~> 0.26.1"
+    }
+
     tls = {
       source  = "hashicorp/tls"
       version = "~> 3.1"

--- a/tests/standalone-mounted-disk/data.tf
+++ b/tests/standalone-mounted-disk/data.tf
@@ -1,5 +1,10 @@
+data "tfe_outputs" "base" {
+  organization = var.tfe.organization
+  workspace    = var.tfe.workspace
+}
+
 data "google_dns_managed_zone" "main" {
-  name = "public"
+  name = data.tfe_outputs.base.values.cloud_dns_name
 }
 
 data "google_compute_image" "ubuntu" {

--- a/tests/standalone-mounted-disk/main.tf
+++ b/tests/standalone-mounted-disk/main.tf
@@ -25,23 +25,23 @@ resource "local_file" "private_key_pem" {
 }
 
 module "tfe" {
-  source                = "../.."
-  disk_path             = "/opt/hashicorp/data"
-  distribution          = "ubuntu"
-  dns_zone_name         = data.google_dns_managed_zone.main.name
-  fqdn                  = "${random_pet.main.id}.${trimsuffix(data.google_dns_managed_zone.main.dns_name, ".")}"
-  namespace             = random_pet.main.id
-  node_count            = 1
-  tfe_license_secret_id = module.secrets.license_secret
-  ssl_certificate_name  = "wildcard"
-
-  iact_subnet_list       = ["0.0.0.0/0"]
-  iact_subnet_time_limit = 60
-  labels                 = local.labels
-  load_balancer          = "PUBLIC"
-  operational_mode       = "disk"
-  vm_disk_source_image   = data.google_compute_image.ubuntu.self_link
-  vm_machine_type        = "n1-standard-4"
+  source                      = "../.."
+  disk_path                   = "/opt/hashicorp/data"
+  distribution                = "ubuntu"
+  dns_zone_name               = data.google_dns_managed_zone.main.name
+  fqdn                        = "${random_pet.main.id}.${trimsuffix(data.google_dns_managed_zone.main.dns_name, ".")}"
+  namespace                   = random_pet.main.id
+  node_count                  = 1
+  tfe_license_secret_id       = module.secrets.license_secret
+  ssl_certificate_name        = data.tfe_outputs.base.values.wildcard_ssl_certificate_name
+  existing_service_account_id = var.existing_service_account_id
+  iact_subnet_list            = ["0.0.0.0/0"]
+  iact_subnet_time_limit      = 60
+  labels                      = local.labels
+  load_balancer               = "PUBLIC"
+  operational_mode            = "disk"
+  vm_disk_source_image        = data.google_compute_image.ubuntu.self_link
+  vm_machine_type             = "n1-standard-4"
   vm_metadata = {
     "ssh-keys" = "${local.ssh_user}:${tls_private_key.main.public_key_openssh} ${local.ssh_user}"
   }

--- a/tests/standalone-mounted-disk/providers.tf
+++ b/tests/standalone-mounted-disk/providers.tf
@@ -1,0 +1,4 @@
+provider "tfe" {
+  hostname = var.tfe.hostname
+  token    = var.tfe.token
+}

--- a/tests/standalone-mounted-disk/variables.tf
+++ b/tests/standalone-mounted-disk/variables.tf
@@ -2,3 +2,18 @@ variable "license_file" {
   type        = string
   description = "The local path to the Terraform Enterprise license to be provided by CI."
 }
+
+variable "existing_service_account_id" {
+  type        = string
+  description = "The id of the logging service account to use for compute resources deployed."
+}
+
+variable "tfe" {
+  description = "Attributes of the Terraform Enterprise instance which manages the base infrastructure."
+  type = object({
+    hostname     = string
+    organization = string
+    token        = string
+    workspace    = string
+  })
+}

--- a/tests/standalone-mounted-disk/versions.tf
+++ b/tests/standalone-mounted-disk/versions.tf
@@ -22,6 +22,11 @@ terraform {
       version = "~> 3.0"
     }
 
+    tfe = {
+      source  = "hashicorp/tfe"
+      version = "~> 0.26.1"
+    }
+
     tls = {
       source  = "hashicorp/tls"
       version = "~> 3.1"

--- a/tests/standalone-mounted-disk/versions.tf
+++ b/tests/standalone-mounted-disk/versions.tf
@@ -24,7 +24,7 @@ terraform {
 
     tfe = {
       source  = "hashicorp/tfe"
-      version = "~> 0.26.1"
+      version = "~> 0.26"
     }
 
     tls = {


### PR DESCRIPTION
## Background

Moving internal tests to the new managed projects has highlighted a few hardcoded elements in the standalone* test cases.  This change introduces output reads from the base resource TFE workspace to obviate the need to maintain these values over time / through certificate rotations.

## How Has This Been Tested

Both standalone test instances have been executed to completion locally.

## This PR makes me feel

<img src="https://media2.giphy.com/media/1nR6fu93A17vWZbO9c/giphy.gif"/>
