### PR TITLE
 TF-440: Remove demo (poc) mode

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -101,7 +101,7 @@ module "redis" {
 # TFE and Replicated settings to pass to the tfe_init module
 # -----------------------------------------------------------------------------
 module "settings" {
-  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/settings?ref=tf-440"
+  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/settings?ref=main
 
   # TFE Base Configuration
   production_type          = var.operational_mode

--- a/main.tf
+++ b/main.tf
@@ -101,7 +101,7 @@ module "redis" {
 # TFE and Replicated settings to pass to the tfe_init module
 # -----------------------------------------------------------------------------
 module "settings" {
-  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/settings?ref=main
+  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/settings?ref=main"
 
   # TFE Base Configuration
   production_type          = var.operational_mode

--- a/main.tf
+++ b/main.tf
@@ -101,10 +101,9 @@ module "redis" {
 # TFE and Replicated settings to pass to the tfe_init module
 # -----------------------------------------------------------------------------
 module "settings" {
-  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/settings?ref=main"
+  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/settings?ref=tf-440"
 
   # TFE Base Configuration
-  installation_type        = "production"
   production_type          = var.operational_mode
   disk_path                = var.disk_path
   iact_subnet_list         = var.iact_subnet_list

--- a/variables.tf
+++ b/variables.tf
@@ -336,13 +336,13 @@ variable "operational_mode" {
   default     = "external"
   description = <<-EOD
   A special string to control the operational mode of Terraform Enterprise. Valid values are: "external" for External
-  Services mode; "disk" for Mounted Disk mode; "poc" for Demo mode.
+  Services mode; "disk" for Mounted Disk mode;.
   EOD
   type        = string
 
   validation {
-    condition     = contains(["external", "disk", "poc"], var.operational_mode)
-    error_message = "The operational_mode value must be one of: \"external\"; \"disk\"; \"poc\"."
+    condition     = contains(["external", "disk"], var.operational_mode)
+    error_message = "The operational_mode value must be one of: \"external\"; \"disk\";."
   }
 }
 
@@ -501,3 +501,4 @@ variable "extern_vault_token_renew" {
   type        = number
   description = "(Optional if var.extern_vault_enable = true) How often (in seconds) to renew the Vault token."
 }
+


### PR DESCRIPTION
## Background

Removing the demo (`poc`) installation mode to get ready for the April release of Terraform Enterprise where it will be removed in the code.

This should not get merged until after the April release of Terraform Enterprise is released.

## How Has This Been Tested

Tested this by building a mounted disk installation of a development Terraform Enterprise version.

### Test Configuration

CI/CD

## This PR makes me feel

![optional gif describing your feelings about this pr](https://media.giphy.com/media/m9eG1qVjvN56H0MXt8/giphy.gif)