### PR TITLE
Add PostgreSQL 14 test coverage to the nightly GCP scenario

### DIFF
--- a/tests/standalone-mounted-disk/main.tf
+++ b/tests/standalone-mounted-disk/main.tf
@@ -42,6 +42,7 @@ module "tfe" {
   operational_mode            = "disk"
   vm_disk_source_image        = data.google_compute_image.ubuntu.self_link
   vm_machine_type             = "n1-standard-4"
+  postgres_version            = "POSTGRES_14"
   vm_metadata = {
     "ssh-keys" = "${local.ssh_user}:${tls_private_key.main.public_key_openssh} ${local.ssh_user}"
   }


### PR DESCRIPTION
## Background

I am Adding PostgreSQL 14 test coverage to the nightly GCP scenario by using a custom branch in ptfe-replicated for circleci, to test this out.

** This is not meant to be merged to main. **