### PR TITLE
Nl postgresql v14 test gcp nightly

### DIFF
--- a/tests/standalone-external-rhel8-worker/main.tf
+++ b/tests/standalone-external-rhel8-worker/main.tf
@@ -52,6 +52,7 @@ module "tfe" {
   operational_mode     = "external"
   vm_disk_source_image = data.google_compute_image.rhel.self_link
   vm_machine_type      = "n1-standard-4"
+  postgres_version     = "POSTGRES_14"
   vm_metadata = {
     "ssh-keys" = "${local.ssh_user}:${tls_private_key.main.public_key_openssh} ${local.ssh_user}"
   }

--- a/tests/standalone-mounted-disk/main.tf
+++ b/tests/standalone-mounted-disk/main.tf
@@ -42,6 +42,7 @@ module "tfe" {
   operational_mode            = "disk"
   vm_disk_source_image        = data.google_compute_image.ubuntu.self_link
   vm_machine_type             = "n1-standard-4"
+  postgres_version            = "POSTGRES_14"
   vm_metadata = {
     "ssh-keys" = "${local.ssh_user}:${tls_private_key.main.public_key_openssh} ${local.ssh_user}"
   }

--- a/tests/standalone-mounted-disk/main.tf
+++ b/tests/standalone-mounted-disk/main.tf
@@ -42,7 +42,7 @@ module "tfe" {
   operational_mode            = "disk"
   vm_disk_source_image        = data.google_compute_image.ubuntu.self_link
   vm_machine_type             = "n1-standard-4"
-  postgres_version            = "POSTGRES_14"
+
   vm_metadata = {
     "ssh-keys" = "${local.ssh_user}:${tls_private_key.main.public_key_openssh} ${local.ssh_user}"
   }


### PR DESCRIPTION
## Background

I am Adding PostgreSQL 14 test coverage to the nightly GCP scenario_google_standalone_external_rhel8_worker by using a custom branch in ptfe-replicated for circleci, to test this out.

** This is not meant to be merged to main. **