### PR TITLE
TFE workspace only accepts string

### DIFF
--- a/tests/private-active-active/data.tf
+++ b/tests/private-active-active/data.tf
@@ -1,6 +1,6 @@
 data "tfe_outputs" "base" {
-  organization = var.tfe.organization
-  workspace    = var.tfe.workspace
+  organization = local.tfe.organization
+  workspace    = local.tfe.workspace
 }
 
 data "google_dns_managed_zone" "main" {

--- a/tests/private-active-active/data.tf
+++ b/tests/private-active-active/data.tf
@@ -1,6 +1,6 @@
 data "tfe_outputs" "base" {
-  organization = try(var.tfe.organization, local.tfe.organization)
-  workspace    = try(var.tfe.workspace, local.tfe.workspace)
+  organization = try(var.tfe.organization, var.tfe_organization)
+  workspace    = try(var.tfe.workspace, var.tfe_workspace)
 }
 
 data "google_dns_managed_zone" "main" {

--- a/tests/private-active-active/data.tf
+++ b/tests/private-active-active/data.tf
@@ -1,6 +1,6 @@
 data "tfe_outputs" "base" {
-  organization = local.tfe.organization
-  workspace    = local.tfe.workspace
+  organization = try(var.tfe.organization, local.tfe.organization)
+  workspace    = try(var.tfe.workspace, local.tfe.workspace)
 }
 
 data "google_dns_managed_zone" "main" {

--- a/tests/private-active-active/locals.tf
+++ b/tests/private-active-active/locals.tf
@@ -1,20 +1,5 @@
 locals {
   name = "${random_pet.main.id}-proxy"
-
-  tfe = {
-    hostname     = var.tfe_hostname
-    organization = var.tfe_organization
-    token        = var.tfe_token
-    workspace    = var.tfe_workspace
-  }
-
-  google = {
-    credentials = var.google_credentials
-    project     = var.google_project
-    region      = var.google_region
-    zone        = var.google_zone
-  }
-
   labels = {
     oktodelete  = "true"
     terraform   = "true"

--- a/tests/private-active-active/locals.tf
+++ b/tests/private-active-active/locals.tf
@@ -5,7 +5,7 @@ locals {
     hostname     = var.tfe_hostname
     organization = var.tfe_organization
     token        = var.tfe_token
-    workspace    = var.workspace
+    workspace    = var.tfe_workspace
   }
 
   google = {

--- a/tests/private-active-active/locals.tf
+++ b/tests/private-active-active/locals.tf
@@ -1,6 +1,20 @@
 locals {
   name = "${random_pet.main.id}-proxy"
 
+  tfe = {
+    hostname     = var.tfe_hostname
+    organization = var.tfe_organization
+    token        = var.tfe_token
+    workspace    = var.workspace
+  }
+
+  google = {
+    credentials = var.google_credentials
+    project     = var.google_project
+    region      = var.google_region
+    zone        = var.google_zone
+  }
+
   labels = {
     oktodelete  = "true"
     terraform   = "true"

--- a/tests/private-active-active/providers.tf
+++ b/tests/private-active-active/providers.tf
@@ -1,18 +1,18 @@
 provider "google" {
-  credentials = var.google.credentials
-  project     = var.google.project
-  region      = var.google.region
-  zone        = var.google.zone
+  credentials = local.google.credentials
+  project     = local.google.project
+  region      = local.google.region
+  zone        = local.google.zone
 }
 
 provider "google-beta" {
-  credentials = var.google.credentials
-  project     = var.google.project
-  region      = var.google.region
-  zone        = var.google.zone
+  credentials = local.google.credentials
+  project     = local.google.project
+  region      = local.google.region
+  zone        = local.google.zone
 }
 
 provider "tfe" {
-  hostname = var.tfe.hostname
-  token    = var.tfe.token
+  hostname = local.tfe.hostname
+  token    = local.tfe.token
 }

--- a/tests/private-active-active/providers.tf
+++ b/tests/private-active-active/providers.tf
@@ -1,18 +1,18 @@
 provider "google" {
-  credentials = try(var.google.credentials, local.google.credentials)
-  project     = try(var.google.project, local.google.project)
-  region      = try(var.google.region, local.google.region)
-  zone        = try(var.google.zone, local.google.zone)
+  credentials = try(var.google.credentials, var.google_credentials)
+  project     = try(var.google.project, var.google_project)
+  region      = try(var.google.region, var.google_region)
+  zone        = try(var.google.zone, var.google_zone)
 }
 
 provider "google-beta" {
-  credentials = try(var.google.credentials, local.google.credentials)
-  project     = try(var.google.project, local.google.project)
-  region      = try(var.google.region, local.google.region)
-  zone        = try(var.google.zone, local.google.zone)
+  credentials = try(var.google.credentials, var.google_credentials)
+  project     = try(var.google.project, var.google_project)
+  region      = try(var.google.region, var.google_region)
+  zone        = try(var.google.zone, var.google_zone)
 }
 
 provider "tfe" {
-  hostname = try(var.tfe.hostname, local.tfe.hostname)
-  token    = try(var.tfe.token, local.tfe.token)
+  hostname = try(var.tfe.hostname, var.tfe_hostname)
+  token    = try(var.tfe.token, var.tfe_token)
 }

--- a/tests/private-active-active/providers.tf
+++ b/tests/private-active-active/providers.tf
@@ -1,18 +1,18 @@
 provider "google" {
-  credentials = local.google.credentials
-  project     = local.google.project
-  region      = local.google.region
-  zone        = local.google.zone
+  credentials = try(var.google.credentials, local.google.credentials)
+  project     = try(var.google.project, local.google.project)
+  region      = try(var.google.region, local.google.region)
+  zone        = try(var.google.zone, local.google.zone)
 }
 
 provider "google-beta" {
-  credentials = local.google.credentials
-  project     = local.google.project
-  region      = local.google.region
-  zone        = local.google.zone
+  credentials = try(var.google.credentials, local.google.credentials)
+  project     = try(var.google.project, local.google.project)
+  region      = try(var.google.region, local.google.region)
+  zone        = try(var.google.zone, local.google.zone)
 }
 
 provider "tfe" {
-  hostname = local.tfe.hostname
-  token    = local.tfe.token
+  hostname = try(var.tfe.hostname, local.tfe.hostname)
+  token    = try(var.tfe.token, local.tfe.token)
 }

--- a/tests/private-active-active/variables.tf
+++ b/tests/private-active-active/variables.tf
@@ -1,3 +1,14 @@
+variable "google" {
+  description = "Attributes of the Google Cloud account which will host the test infrastructure."
+  type = object({
+    credentials     = string
+    project         = string
+    region          = string
+    zone            = string
+    service_account = string
+  })
+}
+
 variable "google_credentials" {
   description = "Credentials of the Google Cloud account which will host the test infrastructure."
   type        = string
@@ -36,4 +47,14 @@ variable "tfe_token" {
 variable "tfe_workspace" {
   description = "Workspace of the Terraform Enterprise instance which manages the base infrastructure."
   type        = string
+}
+
+variable "tfe" {
+  description = "Attributes of the Terraform Enterprise instance which manages the base infrastructure."
+  type = object({
+    hostname     = string
+    organization = string
+    token        = string
+    workspace    = string
+  })
 }

--- a/tests/private-active-active/variables.tf
+++ b/tests/private-active-active/variables.tf
@@ -13,11 +13,6 @@ variable "google_region" {
   type        = string
 }
 
-variable "google_service_account" {
-  description = "Workspace of the Terraform Enterprise instance which manages the base infrastructure."
-  type        = string
-}
-
 variable "google_zone" {
   description = "Workspace of the Terraform Enterprise instance which manages the base infrastructure."
   type        = string

--- a/tests/private-active-active/variables.tf
+++ b/tests/private-active-active/variables.tf
@@ -1,20 +1,44 @@
-variable "google" {
-  description = "Attributes of the Google Cloud account which will host the test infrastructure."
-  type = object({
-    credentials     = string
-    project         = string
-    region          = string
-    zone            = string
-    service_account = string
-  })
+variable "google_credentials" {
+  description = "Credentials of the Google Cloud account which will host the test infrastructure."
+  type        = string
 }
 
-variable "tfe" {
-  description = "Attributes of the Terraform Enterprise instance which manages the base infrastructure."
-  type = object({
-    hostname     = string
-    organization = string
-    token        = string
-    workspace    = string
-  })
+variable "google_project" {
+  description = "Project in the Google Cloud account which will host the test infrastructure."
+  type        = string
+}
+
+variable "google_region" {
+  description = "Region in the Google Cloud account which will host the test infrastructure."
+  type        = string
+}
+
+variable "google_service_account" {
+  description = "Workspace of the Terraform Enterprise instance which manages the base infrastructure."
+  type        = string
+}
+
+variable "google_zone" {
+  description = "Workspace of the Terraform Enterprise instance which manages the base infrastructure."
+  type        = string
+}
+
+variable "tfe_hostname" {
+  description = "Hostname of the Terraform Enterprise instance which manages the base infrastructure."
+  type        = string
+}
+
+variable "tfe_organization" {
+  description = "Organization of the Terraform Enterprise instance which manages the base infrastructure."
+  type        = string
+}
+
+variable "tfe_token" {
+  description = "Token of the Terraform Enterprise instance which manages the base infrastructure."
+  type        = string
+}
+
+variable "tfe_workspace" {
+  description = "Workspace of the Terraform Enterprise instance which manages the base infrastructure."
+  type        = string
 }

--- a/tests/private-active-active/variables.tf
+++ b/tests/private-active-active/variables.tf
@@ -10,41 +10,49 @@ variable "google" {
 }
 
 variable "google_credentials" {
+  default     = null
   description = "Credentials of the Google Cloud account which will host the test infrastructure."
   type        = string
 }
 
 variable "google_project" {
+  default     = null
   description = "Project in the Google Cloud account which will host the test infrastructure."
   type        = string
 }
 
 variable "google_region" {
+  default     = null
   description = "Region in the Google Cloud account which will host the test infrastructure."
   type        = string
 }
 
 variable "google_zone" {
+  default     = null
   description = "Workspace of the Terraform Enterprise instance which manages the base infrastructure."
   type        = string
 }
 
 variable "tfe_hostname" {
+  default     = null
   description = "Hostname of the Terraform Enterprise instance which manages the base infrastructure."
   type        = string
 }
 
 variable "tfe_organization" {
+  default     = null
   description = "Organization of the Terraform Enterprise instance which manages the base infrastructure."
   type        = string
 }
 
 variable "tfe_token" {
+  default     = null
   description = "Token of the Terraform Enterprise instance which manages the base infrastructure."
   type        = string
 }
 
 variable "tfe_workspace" {
+  default     = null
   description = "Workspace of the Terraform Enterprise instance which manages the base infrastructure."
   type        = string
 }

--- a/tests/private-tcp-active-active/data.tf
+++ b/tests/private-tcp-active-active/data.tf
@@ -1,6 +1,6 @@
 data "tfe_outputs" "base" {
-  organization = var.tfe.organization
-  workspace    = var.tfe.workspace
+  organization = local.tfe.organization
+  workspace    = local.tfe.workspace
 }
 
 data "google_dns_managed_zone" "main" {

--- a/tests/private-tcp-active-active/data.tf
+++ b/tests/private-tcp-active-active/data.tf
@@ -1,6 +1,6 @@
 data "tfe_outputs" "base" {
-  organization = try(var.tfe.organization, local.tfe.organization)
-  workspace    = try(var.tfe.workspace, local.tfe.workspace)
+  organization = try(var.tfe.organization, var.tfe_organization)
+  workspace    = try(var.tfe.workspace, var.tfe_workspace)
 }
 
 data "google_dns_managed_zone" "main" {

--- a/tests/private-tcp-active-active/data.tf
+++ b/tests/private-tcp-active-active/data.tf
@@ -1,6 +1,6 @@
 data "tfe_outputs" "base" {
-  organization = local.tfe.organization
-  workspace    = local.tfe.workspace
+  organization = try(var.tfe.organization, local.tfe.organization)
+  workspace    = try(var.tfe.workspace, local.tfe.workspace)
 }
 
 data "google_dns_managed_zone" "main" {

--- a/tests/private-tcp-active-active/locals.tf
+++ b/tests/private-tcp-active-active/locals.tf
@@ -1,5 +1,18 @@
 locals {
   name = "${random_pet.main.id}-proxy"
+  tfe = {
+    hostname     = var.tfe_hostname
+    organization = var.tfe_organization
+    token        = var.tfe_token
+    workspace    = var.workspace
+  }
+
+  google = {
+    credentials = var.google_credentials
+    project     = var.google_project
+    region      = var.google_region
+    zone        = var.google_zone
+  }
 
   labels = {
     oktodelete  = "true"

--- a/tests/private-tcp-active-active/locals.tf
+++ b/tests/private-tcp-active-active/locals.tf
@@ -1,19 +1,5 @@
 locals {
   name = "${random_pet.main.id}-proxy"
-  tfe = {
-    hostname     = var.tfe_hostname
-    organization = var.tfe_organization
-    token        = var.tfe_token
-    workspace    = var.tfe_workspace
-  }
-
-  google = {
-    credentials = var.google_credentials
-    project     = var.google_project
-    region      = var.google_region
-    zone        = var.google_zone
-  }
-
   labels = {
     oktodelete  = "true"
     terraform   = "true"

--- a/tests/private-tcp-active-active/locals.tf
+++ b/tests/private-tcp-active-active/locals.tf
@@ -4,7 +4,7 @@ locals {
     hostname     = var.tfe_hostname
     organization = var.tfe_organization
     token        = var.tfe_token
-    workspace    = var.workspace
+    workspace    = var.tfe_workspace
   }
 
   google = {

--- a/tests/private-tcp-active-active/providers.tf
+++ b/tests/private-tcp-active-active/providers.tf
@@ -1,18 +1,18 @@
 provider "google" {
-  credentials = var.google.credentials
-  project     = var.google.project
-  region      = var.google.region
-  zone        = var.google.zone
+  credentials = local.google.credentials
+  project     = local.google.project
+  region      = local.google.region
+  zone        = local.google.zone
 }
 
 provider "google-beta" {
-  credentials = var.google.credentials
-  project     = var.google.project
-  region      = var.google.region
-  zone        = var.google.zone
+  credentials = local.google.credentials
+  project     = local.google.project
+  region      = local.google.region
+  zone        = local.google.zone
 }
 
 provider "tfe" {
-  hostname = var.tfe.hostname
-  token    = var.tfe.token
+  hostname = local.tfe.hostname
+  token    = local.tfe.token
 }

--- a/tests/private-tcp-active-active/providers.tf
+++ b/tests/private-tcp-active-active/providers.tf
@@ -1,18 +1,18 @@
 provider "google" {
-  credentials = try(var.google.credentials, local.google.credentials)
-  project     = try(var.google.project, local.google.project)
-  region      = try(var.google.region, local.google.region)
-  zone        = try(var.google.zone, local.google.zone)
+  credentials = try(var.google.credentials, var.google_credentials)
+  project     = try(var.google.project, var.google_project)
+  region      = try(var.google.region, var.google_region)
+  zone        = try(var.google.zone, var.google_zone)
 }
 
 provider "google-beta" {
-  credentials = try(var.google.credentials, local.google.credentials)
-  project     = try(var.google.project, local.google.project)
-  region      = try(var.google.region, local.google.region)
-  zone        = try(var.google.zone, local.google.zone)
+  credentials = try(var.google.credentials, var.google_credentials)
+  project     = try(var.google.project, var.google_project)
+  region      = try(var.google.region, var.google_region)
+  zone        = try(var.google.zone, var.google_zone)
 }
 
 provider "tfe" {
-  hostname = try(var.tfe.hostname, local.tfe.hostname)
-  token    = try(var.tfe.token, local.tfe.token)
+  hostname = try(var.tfe.hostname, var.tfe_hostname)
+  token    = try(var.tfe.token, var.tfe_token)
 }

--- a/tests/private-tcp-active-active/providers.tf
+++ b/tests/private-tcp-active-active/providers.tf
@@ -1,18 +1,18 @@
 provider "google" {
-  credentials = local.google.credentials
-  project     = local.google.project
-  region      = local.google.region
-  zone        = local.google.zone
+  credentials = try(var.google.credentials, local.google.credentials)
+  project     = try(var.google.project, local.google.project)
+  region      = try(var.google.region, local.google.region)
+  zone        = try(var.google.zone, local.google.zone)
 }
 
 provider "google-beta" {
-  credentials = local.google.credentials
-  project     = local.google.project
-  region      = local.google.region
-  zone        = local.google.zone
+  credentials = try(var.google.credentials, local.google.credentials)
+  project     = try(var.google.project, local.google.project)
+  region      = try(var.google.region, local.google.region)
+  zone        = try(var.google.zone, local.google.zone)
 }
 
 provider "tfe" {
-  hostname = local.tfe.hostname
-  token    = local.tfe.token
+  hostname = try(var.tfe.hostname, local.tfe.hostname)
+  token    = try(var.tfe.token, local.tfe.token)
 }

--- a/tests/private-tcp-active-active/variables.tf
+++ b/tests/private-tcp-active-active/variables.tf
@@ -1,3 +1,14 @@
+variable "google" {
+  description = "Attributes of the Google Cloud account which will host the test infrastructure."
+  type = object({
+    credentials     = string
+    project         = string
+    region          = string
+    zone            = string
+    service_account = string
+  })
+}
+
 variable "google_credentials" {
   description = "Credentials of the Google Cloud account which will host the test infrastructure."
   type        = string
@@ -36,4 +47,14 @@ variable "tfe_token" {
 variable "tfe_workspace" {
   description = "Workspace of the Terraform Enterprise instance which manages the base infrastructure."
   type        = string
+}
+
+variable "tfe" {
+  description = "Attributes of the Terraform Enterprise instance which manages the base infrastructure."
+  type = object({
+    hostname     = string
+    organization = string
+    token        = string
+    workspace    = string
+  })
 }

--- a/tests/private-tcp-active-active/variables.tf
+++ b/tests/private-tcp-active-active/variables.tf
@@ -13,11 +13,6 @@ variable "google_region" {
   type        = string
 }
 
-variable "google_service_account" {
-  description = "Workspace of the Terraform Enterprise instance which manages the base infrastructure."
-  type        = string
-}
-
 variable "google_zone" {
   description = "Workspace of the Terraform Enterprise instance which manages the base infrastructure."
   type        = string

--- a/tests/private-tcp-active-active/variables.tf
+++ b/tests/private-tcp-active-active/variables.tf
@@ -1,20 +1,44 @@
-variable "google" {
-  description = "Attributes of the Google Cloud account which will host the test infrastructure."
-  type = object({
-    credentials     = string
-    project         = string
-    region          = string
-    zone            = string
-    service_account = string
-  })
+variable "google_credentials" {
+  description = "Credentials of the Google Cloud account which will host the test infrastructure."
+  type        = string
 }
 
-variable "tfe" {
-  description = "Attributes of the Terraform Enterprise instance which manages the base infrastructure."
-  type = object({
-    hostname     = string
-    organization = string
-    token        = string
-    workspace    = string
-  })
+variable "google_project" {
+  description = "Project in the Google Cloud account which will host the test infrastructure."
+  type        = string
+}
+
+variable "google_region" {
+  description = "Region in the Google Cloud account which will host the test infrastructure."
+  type        = string
+}
+
+variable "google_service_account" {
+  description = "Workspace of the Terraform Enterprise instance which manages the base infrastructure."
+  type        = string
+}
+
+variable "google_zone" {
+  description = "Workspace of the Terraform Enterprise instance which manages the base infrastructure."
+  type        = string
+}
+
+variable "tfe_hostname" {
+  description = "Hostname of the Terraform Enterprise instance which manages the base infrastructure."
+  type        = string
+}
+
+variable "tfe_organization" {
+  description = "Organization of the Terraform Enterprise instance which manages the base infrastructure."
+  type        = string
+}
+
+variable "tfe_token" {
+  description = "Token of the Terraform Enterprise instance which manages the base infrastructure."
+  type        = string
+}
+
+variable "tfe_workspace" {
+  description = "Workspace of the Terraform Enterprise instance which manages the base infrastructure."
+  type        = string
 }

--- a/tests/private-tcp-active-active/variables.tf
+++ b/tests/private-tcp-active-active/variables.tf
@@ -10,41 +10,49 @@ variable "google" {
 }
 
 variable "google_credentials" {
+  default     = null
   description = "Credentials of the Google Cloud account which will host the test infrastructure."
   type        = string
 }
 
 variable "google_project" {
+  default     = null
   description = "Project in the Google Cloud account which will host the test infrastructure."
   type        = string
 }
 
 variable "google_region" {
+  default     = null
   description = "Region in the Google Cloud account which will host the test infrastructure."
   type        = string
 }
 
 variable "google_zone" {
+  default     = null
   description = "Workspace of the Terraform Enterprise instance which manages the base infrastructure."
   type        = string
 }
 
 variable "tfe_hostname" {
+  default     = null
   description = "Hostname of the Terraform Enterprise instance which manages the base infrastructure."
   type        = string
 }
 
 variable "tfe_organization" {
+  default     = null
   description = "Organization of the Terraform Enterprise instance which manages the base infrastructure."
   type        = string
 }
 
 variable "tfe_token" {
+  default     = null
   description = "Token of the Terraform Enterprise instance which manages the base infrastructure."
   type        = string
 }
 
 variable "tfe_workspace" {
+  default     = null
   description = "Workspace of the Terraform Enterprise instance which manages the base infrastructure."
   type        = string
 }

--- a/tests/public-active-active/data.tf
+++ b/tests/public-active-active/data.tf
@@ -1,6 +1,6 @@
 data "tfe_outputs" "base" {
-  organization = try(var.tfe.organization, local.tfe.organization)
-  workspace    = try(var.tfe.workspace, local.tfe.workspace)
+  organization = try(var.tfe.organization, var.tfe_organization)
+  workspace    = try(var.tfe.workspace, var.tfe_workspace)
 }
 
 data "google_compute_image" "ubuntu" {

--- a/tests/public-active-active/data.tf
+++ b/tests/public-active-active/data.tf
@@ -1,6 +1,6 @@
 data "tfe_outputs" "base" {
-  organization = var.tfe.organization
-  workspace    = var.tfe.workspace
+  organization = local.tfe.organization
+  workspace    = local.tfe.workspace
 }
 
 data "google_compute_image" "ubuntu" {

--- a/tests/public-active-active/data.tf
+++ b/tests/public-active-active/data.tf
@@ -1,6 +1,6 @@
 data "tfe_outputs" "base" {
-  organization = local.tfe.organization
-  workspace    = local.tfe.workspace
+  organization = try(var.tfe.organization, local.tfe.organization)
+  workspace    = try(var.tfe.workspace, local.tfe.workspace)
 }
 
 data "google_compute_image" "ubuntu" {

--- a/tests/public-active-active/locals.tf
+++ b/tests/public-active-active/locals.tf
@@ -1,15 +1,2 @@
 locals {
-  tfe = {
-    hostname     = var.tfe_hostname
-    organization = var.tfe_organization
-    token        = var.tfe_token
-    workspace    = var.tfe_workspace
-  }
-
-  google = {
-    credentials = var.google_credentials
-    project     = var.google_project
-    region      = var.google_region
-    zone        = var.google_zone
-  }
 }

--- a/tests/public-active-active/locals.tf
+++ b/tests/public-active-active/locals.tf
@@ -1,1 +1,15 @@
-locals {}
+locals {
+  tfe = {
+    hostname     = var.tfe_hostname
+    organization = var.tfe_organization
+    token        = var.tfe_token
+    workspace    = var.workspace
+  }
+
+  google = {
+    credentials = var.google_credentials
+    project     = var.google_project
+    region      = var.google_region
+    zone        = var.google_zone
+  }
+}

--- a/tests/public-active-active/locals.tf
+++ b/tests/public-active-active/locals.tf
@@ -3,7 +3,7 @@ locals {
     hostname     = var.tfe_hostname
     organization = var.tfe_organization
     token        = var.tfe_token
-    workspace    = var.workspace
+    workspace    = var.tfe_workspace
   }
 
   google = {

--- a/tests/public-active-active/providers.tf
+++ b/tests/public-active-active/providers.tf
@@ -1,18 +1,18 @@
 provider "google" {
-  credentials = var.google.credentials
-  project     = var.google.project
-  region      = var.google.region
-  zone        = var.google.zone
+  credentials = local.google.credentials
+  project     = local.google.project
+  region      = local.google.region
+  zone        = local.google.zone
 }
 
 provider "google-beta" {
-  credentials = var.google.credentials
-  project     = var.google.project
-  region      = var.google.region
-  zone        = var.google.zone
+  credentials = local.google.credentials
+  project     = local.google.project
+  region      = local.google.region
+  zone        = local.google.zone
 }
 
 provider "tfe" {
-  hostname = var.tfe.hostname
-  token    = var.tfe.token
+  hostname = local.tfe.hostname
+  token    = local.tfe.token
 }

--- a/tests/public-active-active/providers.tf
+++ b/tests/public-active-active/providers.tf
@@ -1,18 +1,18 @@
 provider "google" {
-  credentials = try(var.google.credentials, local.google.credentials)
-  project     = try(var.google.project, local.google.project)
-  region      = try(var.google.region, local.google.region)
-  zone        = try(var.google.zone, local.google.zone)
+  credentials = try(var.google.credentials, var.google_credentials)
+  project     = try(var.google.project, var.google_project)
+  region      = try(var.google.region, var.google_region)
+  zone        = try(var.google.zone, var.google_zone)
 }
 
 provider "google-beta" {
-  credentials = try(var.google.credentials, local.google.credentials)
-  project     = try(var.google.project, local.google.project)
-  region      = try(var.google.region, local.google.region)
-  zone        = try(var.google.zone, local.google.zone)
+  credentials = try(var.google.credentials, var.google_credentials)
+  project     = try(var.google.project, var.google_project)
+  region      = try(var.google.region, var.google_region)
+  zone        = try(var.google.zone, var.google_zone)
 }
 
 provider "tfe" {
-  hostname = try(var.tfe.hostname, local.tfe.hostname)
-  token    = try(var.tfe.token, local.tfe.token)
+  hostname = try(var.tfe.hostname, var.tfe_hostname)
+  token    = try(var.tfe.token, var.tfe_token)
 }

--- a/tests/public-active-active/providers.tf
+++ b/tests/public-active-active/providers.tf
@@ -1,18 +1,18 @@
 provider "google" {
-  credentials = local.google.credentials
-  project     = local.google.project
-  region      = local.google.region
-  zone        = local.google.zone
+  credentials = try(var.google.credentials, local.google.credentials)
+  project     = try(var.google.project, local.google.project)
+  region      = try(var.google.region, local.google.region)
+  zone        = try(var.google.zone, local.google.zone)
 }
 
 provider "google-beta" {
-  credentials = local.google.credentials
-  project     = local.google.project
-  region      = local.google.region
-  zone        = local.google.zone
+  credentials = try(var.google.credentials, local.google.credentials)
+  project     = try(var.google.project, local.google.project)
+  region      = try(var.google.region, local.google.region)
+  zone        = try(var.google.zone, local.google.zone)
 }
 
 provider "tfe" {
-  hostname = local.tfe.hostname
-  token    = local.tfe.token
+  hostname = try(var.tfe.hostname, local.tfe.hostname)
+  token    = try(var.tfe.token, local.tfe.token)
 }

--- a/tests/public-active-active/variables.tf
+++ b/tests/public-active-active/variables.tf
@@ -10,21 +10,25 @@ variable "google" {
 }
 
 variable "google_credentials" {
+  default     = null
   description = "Credentials of the Google Cloud account which will host the test infrastructure."
   type        = string
 }
 
 variable "google_project" {
+  default     = null
   description = "Project in the Google Cloud account which will host the test infrastructure."
   type        = string
 }
 
 variable "google_region" {
+  default     = null
   description = "Region in the Google Cloud account which will host the test infrastructure."
   type        = string
 }
 
 variable "google_zone" {
+  default     = null
   description = "Workspace of the Terraform Enterprise instance which manages the base infrastructure."
   type        = string
 }
@@ -39,21 +43,25 @@ variable "iact_subnet_list" {
 }
 
 variable "tfe_hostname" {
+  default     = null
   description = "Hostname of the Terraform Enterprise instance which manages the base infrastructure."
   type        = string
 }
 
 variable "tfe_organization" {
+  default     = null
   description = "Organization of the Terraform Enterprise instance which manages the base infrastructure."
   type        = string
 }
 
 variable "tfe_token" {
+  default     = null
   description = "Token of the Terraform Enterprise instance which manages the base infrastructure."
   type        = string
 }
 
 variable "tfe_workspace" {
+  default     = null
   description = "Workspace of the Terraform Enterprise instance which manages the base infrastructure."
   type        = string
 }

--- a/tests/public-active-active/variables.tf
+++ b/tests/public-active-active/variables.tf
@@ -1,12 +1,26 @@
-variable "google" {
-  description = "Attributes of the Google Cloud account which will host the test infrastructure."
-  type = object({
-    credentials     = string
-    project         = string
-    region          = string
-    zone            = string
-    service_account = string
-  })
+variable "google_credentials" {
+  description = "Credentials of the Google Cloud account which will host the test infrastructure."
+  type        = string
+}
+
+variable "google_project" {
+  description = "Project in the Google Cloud account which will host the test infrastructure."
+  type        = string
+}
+
+variable "google_region" {
+  description = "Region in the Google Cloud account which will host the test infrastructure."
+  type        = string
+}
+
+variable "google_service_account" {
+  description = "Workspace of the Terraform Enterprise instance which manages the base infrastructure."
+  type        = string
+}
+
+variable "google_zone" {
+  description = "Workspace of the Terraform Enterprise instance which manages the base infrastructure."
+  type        = string
 }
 
 variable "iact_subnet_list" {
@@ -18,12 +32,22 @@ variable "iact_subnet_list" {
   type        = list(string)
 }
 
-variable "tfe" {
-  description = "Attributes of the Terraform Enterprise instance which manages the base infrastructure."
-  type = object({
-    hostname     = string
-    organization = string
-    token        = string
-    workspace    = string
-  })
+variable "tfe_hostname" {
+  description = "Hostname of the Terraform Enterprise instance which manages the base infrastructure."
+  type        = string
+}
+
+variable "tfe_organization" {
+  description = "Organization of the Terraform Enterprise instance which manages the base infrastructure."
+  type        = string
+}
+
+variable "tfe_token" {
+  description = "Token of the Terraform Enterprise instance which manages the base infrastructure."
+  type        = string
+}
+
+variable "tfe_workspace" {
+  description = "Workspace of the Terraform Enterprise instance which manages the base infrastructure."
+  type        = string
 }

--- a/tests/public-active-active/variables.tf
+++ b/tests/public-active-active/variables.tf
@@ -1,3 +1,14 @@
+variable "google" {
+  description = "Attributes of the Google Cloud account which will host the test infrastructure."
+  type = object({
+    credentials     = string
+    project         = string
+    region          = string
+    zone            = string
+    service_account = string
+  })
+}
+
 variable "google_credentials" {
   description = "Credentials of the Google Cloud account which will host the test infrastructure."
   type        = string
@@ -45,4 +56,14 @@ variable "tfe_token" {
 variable "tfe_workspace" {
   description = "Workspace of the Terraform Enterprise instance which manages the base infrastructure."
   type        = string
+}
+
+variable "tfe" {
+  description = "Attributes of the Terraform Enterprise instance which manages the base infrastructure."
+  type = object({
+    hostname     = string
+    organization = string
+    token        = string
+    workspace    = string
+  })
 }

--- a/tests/public-active-active/variables.tf
+++ b/tests/public-active-active/variables.tf
@@ -13,11 +13,6 @@ variable "google_region" {
   type        = string
 }
 
-variable "google_service_account" {
-  description = "Workspace of the Terraform Enterprise instance which manages the base infrastructure."
-  type        = string
-}
-
 variable "google_zone" {
   description = "Workspace of the Terraform Enterprise instance which manages the base infrastructure."
   type        = string

--- a/tests/public-active-active/versions.tf
+++ b/tests/public-active-active/versions.tf
@@ -25,5 +25,9 @@ terraform {
 
   backend "remote" {
     organization = "terraform-enterprise-modules-test"
+
+    workspaces {
+      name = "google-public-active-active"
+    }
   }
 }

--- a/tests/standalone-external-rhel8-worker/data.tf
+++ b/tests/standalone-external-rhel8-worker/data.tf
@@ -1,6 +1,6 @@
 data "tfe_outputs" "base" {
-  organization = var.tfe.organization
-  workspace    = var.tfe.workspace
+  organization = local.tfe.organization
+  workspace    = local.tfe.workspace
 }
 
 data "google_dns_managed_zone" "main" {

--- a/tests/standalone-external-rhel8-worker/data.tf
+++ b/tests/standalone-external-rhel8-worker/data.tf
@@ -1,6 +1,6 @@
 data "tfe_outputs" "base" {
-  organization = try(var.tfe.organization, local.tfe.organization)
-  workspace    = try(var.tfe.workspace, local.tfe.workspace)
+  organization = try(var.tfe.organization, var.tfe_organization)
+  workspace    = try(var.tfe.workspace, var.tfe_workspace)
 }
 
 data "google_dns_managed_zone" "main" {

--- a/tests/standalone-external-rhel8-worker/data.tf
+++ b/tests/standalone-external-rhel8-worker/data.tf
@@ -1,6 +1,6 @@
 data "tfe_outputs" "base" {
-  organization = local.tfe.organization
-  workspace    = local.tfe.workspace
+  organization = try(var.tfe.organization, local.tfe.organization)
+  workspace    = try(var.tfe.workspace, local.tfe.workspace)
 }
 
 data "google_dns_managed_zone" "main" {

--- a/tests/standalone-external-rhel8-worker/locals.tf
+++ b/tests/standalone-external-rhel8-worker/locals.tf
@@ -2,4 +2,17 @@ locals {
   repository_location = "us-west1"
   repository_name     = "terraform-build-worker"
   ssh_user            = "ubuntu"
+  tfe = {
+    hostname     = var.tfe_hostname
+    organization = var.tfe_organization
+    token        = var.tfe_token
+    workspace    = var.workspace
+  }
+
+  google = {
+    credentials = var.google_credentials
+    project     = var.google_project
+    region      = var.google_region
+    zone        = var.google_zone
+  }
 }

--- a/tests/standalone-external-rhel8-worker/locals.tf
+++ b/tests/standalone-external-rhel8-worker/locals.tf
@@ -2,17 +2,4 @@ locals {
   repository_location = "us-west1"
   repository_name     = "terraform-build-worker"
   ssh_user            = "ubuntu"
-  tfe = {
-    hostname     = var.tfe_hostname
-    organization = var.tfe_organization
-    token        = var.tfe_token
-    workspace    = var.tfe_workspace
-  }
-
-  google = {
-    credentials = var.google_credentials
-    project     = var.google_project
-    region      = var.google_region
-    zone        = var.google_zone
-  }
 }

--- a/tests/standalone-external-rhel8-worker/locals.tf
+++ b/tests/standalone-external-rhel8-worker/locals.tf
@@ -6,7 +6,7 @@ locals {
     hostname     = var.tfe_hostname
     organization = var.tfe_organization
     token        = var.tfe_token
-    workspace    = var.workspace
+    workspace    = var.tfe_workspace
   }
 
   google = {

--- a/tests/standalone-external-rhel8-worker/providers.tf
+++ b/tests/standalone-external-rhel8-worker/providers.tf
@@ -1,4 +1,18 @@
+provider "google" {
+  credentials = local.google.credentials
+  project     = local.google.project
+  region      = local.google.region
+  zone        = local.google.zone
+}
+
+provider "google-beta" {
+  credentials = local.google.credentials
+  project     = local.google.project
+  region      = local.google.region
+  zone        = local.google.zone
+}
+
 provider "tfe" {
-  hostname = var.tfe.hostname
-  token    = var.tfe.token
+  hostname = local.tfe.hostname
+  token    = local.tfe.token
 }

--- a/tests/standalone-external-rhel8-worker/providers.tf
+++ b/tests/standalone-external-rhel8-worker/providers.tf
@@ -1,15 +1,15 @@
 provider "google" {
-  credentials = try(var.google.credentials, local.google.credentials)
-  project     = try(var.google.project, local.google.project)
-  region      = try(var.google.region, local.google.region)
-  zone        = try(var.google.zone, local.google.zone)
+  credentials = local.google.credentials
+  project     = local.google.project
+  region      = local.google.region
+  zone        = local.google.zone
 }
 
 provider "google-beta" {
-  credentials = try(var.google.credentials, local.google.credentials)
-  project     = try(var.google.project, local.google.project)
-  region      = try(var.google.region, local.google.region)
-  zone        = try(var.google.zone, local.google.zone)
+  credentials = local.google.credentials
+  project     = local.google.project
+  region      = local.google.region
+  zone        = local.google.zone
 }
 
 provider "tfe" {

--- a/tests/standalone-external-rhel8-worker/providers.tf
+++ b/tests/standalone-external-rhel8-worker/providers.tf
@@ -1,18 +1,18 @@
 provider "google" {
-  credentials = local.google.credentials
-  project     = local.google.project
-  region      = local.google.region
-  zone        = local.google.zone
+  credentials = var.google_credentials
+  project     = var.google_project
+  region      = var.google_region
+  zone        = var.google_zone
 }
 
 provider "google-beta" {
-  credentials = local.google.credentials
-  project     = local.google.project
-  region      = local.google.region
-  zone        = local.google.zone
+  credentials = var.google_credentials
+  project     = var.google_project
+  region      = var.google_region
+  zone        = var.google_zone
 }
 
 provider "tfe" {
-  hostname = try(var.tfe.hostname, local.tfe.hostname)
-  token    = try(var.tfe.token, local.tfe.token)
+  hostname = try(var.tfe.hostname, var.tfe_hostname)
+  token    = try(var.tfe.token, var.tfe_token)
 }

--- a/tests/standalone-external-rhel8-worker/providers.tf
+++ b/tests/standalone-external-rhel8-worker/providers.tf
@@ -1,18 +1,18 @@
 provider "google" {
-  credentials = local.google.credentials
-  project     = local.google.project
-  region      = local.google.region
-  zone        = local.google.zone
+  credentials = try(var.google.credentials, local.google.credentials)
+  project     = try(var.google.project, local.google.project)
+  region      = try(var.google.region, local.google.region)
+  zone        = try(var.google.zone, local.google.zone)
 }
 
 provider "google-beta" {
-  credentials = local.google.credentials
-  project     = local.google.project
-  region      = local.google.region
-  zone        = local.google.zone
+  credentials = try(var.google.credentials, local.google.credentials)
+  project     = try(var.google.project, local.google.project)
+  region      = try(var.google.region, local.google.region)
+  zone        = try(var.google.zone, local.google.zone)
 }
 
 provider "tfe" {
-  hostname = local.tfe.hostname
-  token    = local.tfe.token
+  hostname = try(var.tfe.hostname, local.tfe.hostname)
+  token    = try(var.tfe.token, local.tfe.token)
 }

--- a/tests/standalone-external-rhel8-worker/variables.tf
+++ b/tests/standalone-external-rhel8-worker/variables.tf
@@ -25,11 +25,6 @@ variable "google_region" {
   type        = string
 }
 
-variable "google_service_account" {
-  description = "Workspace of the Terraform Enterprise instance which manages the base infrastructure."
-  type        = string
-}
-
 variable "google_zone" {
   description = "Workspace of the Terraform Enterprise instance which manages the base infrastructure."
   type        = string

--- a/tests/standalone-external-rhel8-worker/variables.tf
+++ b/tests/standalone-external-rhel8-worker/variables.tf
@@ -10,26 +10,31 @@ variable "license_file" {
 }
 
 variable "google_credentials" {
+  default     = null
   description = "Credentials of the Google Cloud account which will host the test infrastructure."
   type        = string
 }
 
 variable "google_project" {
+  default     = null
   description = "Project in the Google Cloud account which will host the test infrastructure."
   type        = string
 }
 
 variable "google_region" {
+  default     = null
   description = "Region in the Google Cloud account which will host the test infrastructure."
   type        = string
 }
 
 variable "google_zone" {
+  default     = null
   description = "Workspace of the Terraform Enterprise instance which manages the base infrastructure."
   type        = string
 }
 
 variable "tfe_hostname" {
+  default     = null
   description = "Hostname of the Terraform Enterprise instance which manages the base infrastructure."
   type        = string
 }
@@ -41,16 +46,19 @@ variable "tfe_license_secret_id" {
 }
 
 variable "tfe_organization" {
+  default     = null
   description = "Organization of the Terraform Enterprise instance which manages the base infrastructure."
   type        = string
 }
 
 variable "tfe_token" {
+  default     = null
   description = "Token of the Terraform Enterprise instance which manages the base infrastructure."
   type        = string
 }
 
 variable "tfe_workspace" {
+  default     = null
   description = "Workspace of the Terraform Enterprise instance which manages the base infrastructure."
   type        = string
 }

--- a/tests/standalone-external-rhel8-worker/variables.tf
+++ b/tests/standalone-external-rhel8-worker/variables.tf
@@ -9,18 +9,54 @@ variable "license_file" {
   description = "The local path to the Terraform Enterprise license to be provided by CI."
 }
 
-variable "tfe" {
-  description = "Attributes of the Terraform Enterprise instance which manages the base infrastructure."
-  type = object({
-    hostname     = string
-    organization = string
-    token        = string
-    workspace    = string
-  })
+
+variable "google_credentials" {
+  description = "Credentials of the Google Cloud account which will host the test infrastructure."
+  type        = string
+}
+
+variable "google_project" {
+  description = "Project in the Google Cloud account which will host the test infrastructure."
+  type        = string
+}
+
+variable "google_region" {
+  description = "Region in the Google Cloud account which will host the test infrastructure."
+  type        = string
+}
+
+variable "google_service_account" {
+  description = "Workspace of the Terraform Enterprise instance which manages the base infrastructure."
+  type        = string
+}
+
+variable "google_zone" {
+  description = "Workspace of the Terraform Enterprise instance which manages the base infrastructure."
+  type        = string
+}
+
+variable "tfe_hostname" {
+  description = "Hostname of the Terraform Enterprise instance which manages the base infrastructure."
+  type        = string
 }
 
 variable "tfe_license_secret_id" {
   default     = null
   type        = string
   description = "The Secrets Manager secret ARN under which the Base64 encoded Terraform Enterprise license is stored."
+}
+
+variable "tfe_organization" {
+  description = "Organization of the Terraform Enterprise instance which manages the base infrastructure."
+  type        = string
+}
+
+variable "tfe_token" {
+  description = "Token of the Terraform Enterprise instance which manages the base infrastructure."
+  type        = string
+}
+
+variable "tfe_workspace" {
+  description = "Workspace of the Terraform Enterprise instance which manages the base infrastructure."
+  type        = string
 }

--- a/tests/standalone-external-rhel8-worker/variables.tf
+++ b/tests/standalone-external-rhel8-worker/variables.tf
@@ -9,7 +9,6 @@ variable "license_file" {
   description = "The local path to the Terraform Enterprise license to be provided by CI."
 }
 
-
 variable "google_credentials" {
   description = "Credentials of the Google Cloud account which will host the test infrastructure."
   type        = string
@@ -54,4 +53,14 @@ variable "tfe_token" {
 variable "tfe_workspace" {
   description = "Workspace of the Terraform Enterprise instance which manages the base infrastructure."
   type        = string
+}
+
+variable "tfe" {
+  description = "Attributes of the Terraform Enterprise instance which manages the base infrastructure."
+  type = object({
+    hostname     = string
+    organization = string
+    token        = string
+    workspace    = string
+  })
 }

--- a/tests/standalone-mounted-disk/data.tf
+++ b/tests/standalone-mounted-disk/data.tf
@@ -1,6 +1,6 @@
 data "tfe_outputs" "base" {
-  organization = var.tfe.organization
-  workspace    = var.tfe.workspace
+  organization = local.tfe.organization
+  workspace    = local.tfe.workspace
 }
 
 data "google_dns_managed_zone" "main" {

--- a/tests/standalone-mounted-disk/data.tf
+++ b/tests/standalone-mounted-disk/data.tf
@@ -1,6 +1,6 @@
 data "tfe_outputs" "base" {
-  organization = try(var.tfe.organization, local.tfe.organization)
-  workspace    = try(var.tfe.workspace, local.tfe.workspace)
+  organization = try(var.tfe.organization, var.tfe_organization)
+  workspace    = try(var.tfe.workspace, var.tfe_workspace)
 }
 
 data "google_dns_managed_zone" "main" {

--- a/tests/standalone-mounted-disk/data.tf
+++ b/tests/standalone-mounted-disk/data.tf
@@ -1,6 +1,6 @@
 data "tfe_outputs" "base" {
-  organization = local.tfe.organization
-  workspace    = local.tfe.workspace
+  organization = try(var.tfe.organization, local.tfe.organization)
+  workspace    = try(var.tfe.workspace, local.tfe.workspace)
 }
 
 data "google_dns_managed_zone" "main" {

--- a/tests/standalone-mounted-disk/locals.tf
+++ b/tests/standalone-mounted-disk/locals.tf
@@ -10,17 +10,4 @@ locals {
     terraform   = "true"
   }
   ssh_user = "ubuntu"
-  tfe = {
-    hostname     = var.tfe_hostname
-    organization = var.tfe_organization
-    token        = var.tfe_token
-    workspace    = var.tfe_workspace
-  }
-
-  google = {
-    credentials = var.google_credentials
-    project     = var.google_project
-    region      = var.google_region
-    zone        = var.google_zone
-  }
 }

--- a/tests/standalone-mounted-disk/locals.tf
+++ b/tests/standalone-mounted-disk/locals.tf
@@ -14,7 +14,7 @@ locals {
     hostname     = var.tfe_hostname
     organization = var.tfe_organization
     token        = var.tfe_token
-    workspace    = var.workspace
+    workspace    = var.tfe_workspace
   }
 
   google = {

--- a/tests/standalone-mounted-disk/locals.tf
+++ b/tests/standalone-mounted-disk/locals.tf
@@ -10,4 +10,17 @@ locals {
     terraform   = "true"
   }
   ssh_user = "ubuntu"
+  tfe = {
+    hostname     = var.tfe_hostname
+    organization = var.tfe_organization
+    token        = var.tfe_token
+    workspace    = var.workspace
+  }
+
+  google = {
+    credentials = var.google_credentials
+    project     = var.google_project
+    region      = var.google_region
+    zone        = var.google_zone
+  }
 }

--- a/tests/standalone-mounted-disk/providers.tf
+++ b/tests/standalone-mounted-disk/providers.tf
@@ -1,4 +1,18 @@
+provider "google" {
+  credentials = local.google.credentials
+  project     = local.google.project
+  region      = local.google.region
+  zone        = local.google.zone
+}
+
+provider "google-beta" {
+  credentials = local.google.credentials
+  project     = local.google.project
+  region      = local.google.region
+  zone        = local.google.zone
+}
+
 provider "tfe" {
-  hostname = var.tfe.hostname
-  token    = var.tfe.token
+  hostname = local.tfe.hostname
+  token    = local.tfe.token
 }

--- a/tests/standalone-mounted-disk/providers.tf
+++ b/tests/standalone-mounted-disk/providers.tf
@@ -1,15 +1,15 @@
 provider "google" {
-  credentials = try(var.google.credentials, local.google.credentials)
-  project     = try(var.google.project, local.google.project)
-  region      = try(var.google.region, local.google.region)
-  zone        = try(var.google.zone, local.google.zone)
+  credentials = local.google.credentials
+  project     = local.google.project
+  region      = local.google.region
+  zone        = local.google.zone
 }
 
 provider "google-beta" {
-  credentials = try(var.google.credentials, local.google.credentials)
-  project     = try(var.google.project, local.google.project)
-  region      = try(var.google.region, local.google.region)
-  zone        = try(var.google.zone, local.google.zone)
+  credentials = local.google.credentials
+  project     = local.google.project
+  region      = local.google.region
+  zone        = local.google.zone
 }
 
 provider "tfe" {

--- a/tests/standalone-mounted-disk/providers.tf
+++ b/tests/standalone-mounted-disk/providers.tf
@@ -1,18 +1,18 @@
 provider "google" {
-  credentials = local.google.credentials
-  project     = local.google.project
-  region      = local.google.region
-  zone        = local.google.zone
+  credentials = var.google_credentials
+  project     = var.google_project
+  region      = var.google_region
+  zone        = var.google_zone
 }
 
 provider "google-beta" {
-  credentials = local.google.credentials
-  project     = local.google.project
-  region      = local.google.region
-  zone        = local.google.zone
+  credentials = var.google_credentials
+  project     = var.google_project
+  region      = var.google_region
+  zone        = var.google_zone
 }
 
 provider "tfe" {
-  hostname = try(var.tfe.hostname, local.tfe.hostname)
-  token    = try(var.tfe.token, local.tfe.token)
+  hostname = try(var.tfe.hostname, var.tfe_hostname)
+  token    = try(var.tfe.token, var.tfe_token)
 }

--- a/tests/standalone-mounted-disk/providers.tf
+++ b/tests/standalone-mounted-disk/providers.tf
@@ -1,18 +1,18 @@
 provider "google" {
-  credentials = local.google.credentials
-  project     = local.google.project
-  region      = local.google.region
-  zone        = local.google.zone
+  credentials = try(var.google.credentials, local.google.credentials)
+  project     = try(var.google.project, local.google.project)
+  region      = try(var.google.region, local.google.region)
+  zone        = try(var.google.zone, local.google.zone)
 }
 
 provider "google-beta" {
-  credentials = local.google.credentials
-  project     = local.google.project
-  region      = local.google.region
-  zone        = local.google.zone
+  credentials = try(var.google.credentials, local.google.credentials)
+  project     = try(var.google.project, local.google.project)
+  region      = try(var.google.region, local.google.region)
+  zone        = try(var.google.zone, local.google.zone)
 }
 
 provider "tfe" {
-  hostname = local.tfe.hostname
-  token    = local.tfe.token
+  hostname = try(var.tfe.hostname, local.tfe.hostname)
+  token    = try(var.tfe.token, local.tfe.token)
 }

--- a/tests/standalone-mounted-disk/variables.tf
+++ b/tests/standalone-mounted-disk/variables.tf
@@ -54,3 +54,13 @@ variable "tfe_workspace" {
   description = "Workspace of the Terraform Enterprise instance which manages the base infrastructure."
   type        = string
 }
+
+variable "tfe" {
+  description = "Attributes of the Terraform Enterprise instance which manages the base infrastructure."
+  type = object({
+    hostname     = string
+    organization = string
+    token        = string
+    workspace    = string
+  })
+}

--- a/tests/standalone-mounted-disk/variables.tf
+++ b/tests/standalone-mounted-disk/variables.tf
@@ -1,4 +1,5 @@
 variable "existing_service_account_id" {
+  default     = null
   type        = string
   description = "The id of the logging service account to use for compute resources deployed."
 }
@@ -10,26 +11,31 @@ variable "license_file" {
 }
 
 variable "google_credentials" {
+  default     = null
   description = "Credentials of the Google Cloud account which will host the test infrastructure."
   type        = string
 }
 
 variable "google_project" {
+  default     = null
   description = "Project in the Google Cloud account which will host the test infrastructure."
   type        = string
 }
 
 variable "google_region" {
+  default     = null
   description = "Region in the Google Cloud account which will host the test infrastructure."
   type        = string
 }
 
 variable "google_zone" {
+  default     = null
   description = "Workspace of the Terraform Enterprise instance which manages the base infrastructure."
   type        = string
 }
 
 variable "tfe_hostname" {
+  default     = null
   description = "Hostname of the Terraform Enterprise instance which manages the base infrastructure."
   type        = string
 }
@@ -41,16 +47,19 @@ variable "tfe_license_secret_id" {
 }
 
 variable "tfe_organization" {
+  default     = null
   description = "Organization of the Terraform Enterprise instance which manages the base infrastructure."
   type        = string
 }
 
 variable "tfe_token" {
+  default     = null
   description = "Token of the Terraform Enterprise instance which manages the base infrastructure."
   type        = string
 }
 
 variable "tfe_workspace" {
+  default     = null
   description = "Workspace of the Terraform Enterprise instance which manages the base infrastructure."
   type        = string
 }

--- a/tests/standalone-mounted-disk/variables.tf
+++ b/tests/standalone-mounted-disk/variables.tf
@@ -9,18 +9,53 @@ variable "license_file" {
   description = "The local path to the Terraform Enterprise license to be provided by CI."
 }
 
-variable "tfe" {
-  description = "Attributes of the Terraform Enterprise instance which manages the base infrastructure."
-  type = object({
-    hostname     = string
-    organization = string
-    token        = string
-    workspace    = string
-  })
+variable "google_credentials" {
+  description = "Credentials of the Google Cloud account which will host the test infrastructure."
+  type        = string
+}
+
+variable "google_project" {
+  description = "Project in the Google Cloud account which will host the test infrastructure."
+  type        = string
+}
+
+variable "google_region" {
+  description = "Region in the Google Cloud account which will host the test infrastructure."
+  type        = string
+}
+
+variable "google_service_account" {
+  description = "Workspace of the Terraform Enterprise instance which manages the base infrastructure."
+  type        = string
+}
+
+variable "google_zone" {
+  description = "Workspace of the Terraform Enterprise instance which manages the base infrastructure."
+  type        = string
+}
+
+variable "tfe_hostname" {
+  description = "Hostname of the Terraform Enterprise instance which manages the base infrastructure."
+  type        = string
 }
 
 variable "tfe_license_secret_id" {
   default     = null
   type        = string
   description = "The Secrets Manager secret ARN under which the Base64 encoded Terraform Enterprise license is stored."
+}
+
+variable "tfe_organization" {
+  description = "Organization of the Terraform Enterprise instance which manages the base infrastructure."
+  type        = string
+}
+
+variable "tfe_token" {
+  description = "Token of the Terraform Enterprise instance which manages the base infrastructure."
+  type        = string
+}
+
+variable "tfe_workspace" {
+  description = "Workspace of the Terraform Enterprise instance which manages the base infrastructure."
+  type        = string
 }

--- a/tests/standalone-mounted-disk/variables.tf
+++ b/tests/standalone-mounted-disk/variables.tf
@@ -24,11 +24,6 @@ variable "google_region" {
   type        = string
 }
 
-variable "google_service_account" {
-  description = "Workspace of the Terraform Enterprise instance which manages the base infrastructure."
-  type        = string
-}
-
 variable "google_zone" {
   description = "Workspace of the Terraform Enterprise instance which manages the base infrastructure."
   type        = string

--- a/tests/standalone-mounted-disk/versions.tf
+++ b/tests/standalone-mounted-disk/versions.tf
@@ -7,6 +7,11 @@ terraform {
       version = "~> 3.54"
     }
 
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 3.54"
+    }
+
     local = {
       source  = "hashicorp/local"
       version = "~> 2.1"


### PR DESCRIPTION
## Background

Changing input vars to string for creating TFE workspaces for tests as workspace only accept string var.

## How Has This Been Tested

[circle CI tests
](https://app.circleci.com/pipelines/github/hashicorp/ptfe-replicated/4270/workflows/2aad9c13-9e19-460e-95a0-a783017e4c04)
