### PR TITLE
null value not setting default

### DIFF
--- a/tests/standalone-external-rhel8-worker/locals.tf
+++ b/tests/standalone-external-rhel8-worker/locals.tf
@@ -2,4 +2,5 @@ locals {
   repository_location = "us-west1"
   repository_name     = "terraform-build-worker"
   ssh_user            = "ubuntu"
+  utility_module_test = var.license_file == null
 }

--- a/tests/standalone-external-rhel8-worker/main.tf
+++ b/tests/standalone-external-rhel8-worker/main.tf
@@ -7,7 +7,7 @@ resource "random_pet" "main" {
 # Store TFE License as secret
 # ---------------------------
 module "secrets" {
-  count  = length(var.license_file)
+  count  = local.utility_module_test ? 0 : 1
   source = "../../fixtures/secrets"
 
   license = {

--- a/tests/standalone-mounted-disk/locals.tf
+++ b/tests/standalone-mounted-disk/locals.tf
@@ -9,5 +9,6 @@ locals {
     team        = "terraform-enterprise-on-prem"
     terraform   = "true"
   }
-  ssh_user = "ubuntu"
+  ssh_user            = "ubuntu"
+  utility_module_test = var.license_file == null
 }

--- a/tests/standalone-mounted-disk/main.tf
+++ b/tests/standalone-mounted-disk/main.tf
@@ -7,7 +7,7 @@ resource "random_pet" "main" {
 # Store TFE License as secret
 # ---------------------------
 module "secrets" {
-  count  = length(var.license_file)
+  count  = local.utility_module_test ? 0 : 1
   source = "../../fixtures/secrets"
 
   license = {


### PR DESCRIPTION
## Background

Using locals (similar to AWS mod) to set value for count in secret fixture as this value cannot be null.

Error: Invalid function argument
  on main.tf line 10, in module "secrets":
  10:   count  = length(var.license_file)
    ├────────────────
    │ var.license_file is null
Invalid value for "value" parameter: argument must not be null.