### PR TITLE
Error null

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -854,6 +854,7 @@ jobs:
           google_credentials     = <<-EOC
             $GOOGLE_CREDENTIALS
             EOC
+          tfe_license_secret_id  = null
           google_project         = "$GOOGLE_PROJECT"
           google_region          = "$GOOGLE_REGION"
           google_zone            = "$GOOGLE_ZONE"
@@ -1007,6 +1008,7 @@ jobs:
           google_credentials     = <<-EOC
             $GOOGLE_CREDENTIALS
             EOC
+          tfe_license_secret_id  = null
           google_project         = "$GOOGLE_PROJECT"
           google_region          = "$GOOGLE_REGION"
           google_zone            = "$GOOGLE_ZONE"

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -851,6 +851,7 @@ jobs:
           TFE_WORKSPACE: ${{ secrets.TFE_WORKSPACE }}
         run: |
           cat <<EOF > github.auto.tfvars
+          license_file = ""
           google_credentials     = <<-EOC
             $GOOGLE_CREDENTIALS
             EOC
@@ -1004,6 +1005,7 @@ jobs:
           TFE_WORKSPACE: ${{ secrets.TFE_WORKSPACE }}
         run: |
           cat <<EOF > github.auto.tfvars
+          license_file = ""
           google_credentials     = <<-EOC
             $GOOGLE_CREDENTIALS
             EOC

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -854,7 +854,6 @@ jobs:
           google_credentials     = <<-EOC
             $GOOGLE_CREDENTIALS
             EOC
-          tfe_license_secret_id  = null
           google_project         = "$GOOGLE_PROJECT"
           google_region          = "$GOOGLE_REGION"
           google_zone            = "$GOOGLE_ZONE"
@@ -1008,7 +1007,6 @@ jobs:
           google_credentials     = <<-EOC
             $GOOGLE_CREDENTIALS
             EOC
-          tfe_license_secret_id  = null
           google_project         = "$GOOGLE_PROJECT"
           google_region          = "$GOOGLE_REGION"
           google_zone            = "$GOOGLE_ZONE"

--- a/tests/private-active-active/versions.tf
+++ b/tests/private-active-active/versions.tf
@@ -4,12 +4,12 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.90.1"
+      version = "~> 3.54"
     }
 
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.90.1"
+      version = "~> 3.54"
     }
 
     random = {

--- a/tests/private-active-active/versions.tf
+++ b/tests/private-active-active/versions.tf
@@ -4,12 +4,12 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.54"
+      version = "~> 3.90"
     }
 
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.54"
+      version = "~> 3.90"
     }
 
     random = {

--- a/tests/private-tcp-active-active/versions.tf
+++ b/tests/private-tcp-active-active/versions.tf
@@ -4,12 +4,12 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.90.1"
+      version = "~> 3.54"
     }
 
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.90.1"
+      version = "~> 3.54"
     }
 
     random = {

--- a/tests/private-tcp-active-active/versions.tf
+++ b/tests/private-tcp-active-active/versions.tf
@@ -4,12 +4,12 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.54"
+      version = "~> 3.90"
     }
 
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.54"
+      version = "~> 3.90"
     }
 
     random = {

--- a/tests/public-active-active/versions.tf
+++ b/tests/public-active-active/versions.tf
@@ -4,12 +4,12 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.90.1"
+      version = "~> 3.54"
     }
 
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.90.1"
+      version = "~> 3.54"
     }
 
     random = {

--- a/tests/public-active-active/versions.tf
+++ b/tests/public-active-active/versions.tf
@@ -4,12 +4,12 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.54"
+      version = "~> 3.90"
     }
 
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.54"
+      version = "~> 3.90"
     }
 
     random = {

--- a/tests/standalone-external-rhel8-worker/data.tf
+++ b/tests/standalone-external-rhel8-worker/data.tf
@@ -13,7 +13,7 @@ data "google_compute_image" "rhel" {
 }
 
 data "google_compute_region_instance_group" "tfe" {
-  self_link = null_resource.wait_for_instances.triggers.self_link
+  self_link = module.tfe.vm_mig.instance_group
 }
 
 data "google_compute_instance" "tfe" {

--- a/tests/standalone-external-rhel8-worker/locals.tf
+++ b/tests/standalone-external-rhel8-worker/locals.tf
@@ -2,4 +2,5 @@ locals {
   repository_location = "us-west1"
   repository_name     = "terraform-build-worker"
   ssh_user            = "ubuntu"
+  utility_module_test = var.license_file == null
 }

--- a/tests/standalone-external-rhel8-worker/locals.tf
+++ b/tests/standalone-external-rhel8-worker/locals.tf
@@ -2,5 +2,4 @@ locals {
   repository_location = "us-west1"
   repository_name     = "terraform-build-worker"
   ssh_user            = "ubuntu"
-  utility_module_test = var.license_file == null
 }

--- a/tests/standalone-external-rhel8-worker/main.tf
+++ b/tests/standalone-external-rhel8-worker/main.tf
@@ -7,7 +7,7 @@ resource "random_pet" "main" {
 # Store TFE License as secret
 # ---------------------------
 module "secrets" {
-  count  = local.utility_module_test ? 0 : 1
+  count =  length(var.license_file) > 0 ? 1 : 0
   source = "../../fixtures/secrets"
 
   license = {

--- a/tests/standalone-external-rhel8-worker/main.tf
+++ b/tests/standalone-external-rhel8-worker/main.tf
@@ -7,7 +7,7 @@ resource "random_pet" "main" {
 # Store TFE License as secret
 # ---------------------------
 module "secrets" {
-  count  = local.utility_module_test ? 0 : 1
+  count  = length(var.license_file)
   source = "../../fixtures/secrets"
 
   license = {

--- a/tests/standalone-external-rhel8-worker/main.tf
+++ b/tests/standalone-external-rhel8-worker/main.tf
@@ -7,7 +7,7 @@ resource "random_pet" "main" {
 # Store TFE License as secret
 # ---------------------------
 module "secrets" {
-  count  = length(var.license_file)
+  count  = local.utility_module_test ? 0 : 1
   source = "../../fixtures/secrets"
 
   license = {

--- a/tests/standalone-external-rhel8-worker/main.tf
+++ b/tests/standalone-external-rhel8-worker/main.tf
@@ -7,7 +7,7 @@ resource "random_pet" "main" {
 # Store TFE License as secret
 # ---------------------------
 module "secrets" {
-  utility_module_test = var.license_file == null
+  count = local.utility_module_test ? 0 : 1
   source = "../../fixtures/secrets"
 
   license = {

--- a/tests/standalone-external-rhel8-worker/main.tf
+++ b/tests/standalone-external-rhel8-worker/main.tf
@@ -35,7 +35,7 @@ module "tfe" {
   fqdn                        = "${random_pet.main.id}.${trimsuffix(data.google_dns_managed_zone.main.dns_name, ".")}"
   namespace                   = random_pet.main.id
   node_count                  = 1
-  tfe_license_secret_id       = try(module.secrets[0].license_secret, var.tfe_license_secret_id, data.tfe_outputs.base.values.license_secret_id)
+  tfe_license_secret_id       = try(module.secrets[0].license_secret, data.tfe_outputs.base.values.license_secret_id)
   ssl_certificate_name        = data.tfe_outputs.base.values.wildcard_ssl_certificate_name
   existing_service_account_id = var.existing_service_account_id
   custom_image_tag            = "${local.repository_location}-docker.pkg.dev/ptfe-testing/${local.repository_name}/rhel-7.9:latest"

--- a/tests/standalone-external-rhel8-worker/main.tf
+++ b/tests/standalone-external-rhel8-worker/main.tf
@@ -7,7 +7,7 @@ resource "random_pet" "main" {
 # Store TFE License as secret
 # ---------------------------
 module "secrets" {
-  count = local.utility_module_test ? 0 : 1
+  count  = local.utility_module_test ? 0 : 1
   source = "../../fixtures/secrets"
 
   license = {

--- a/tests/standalone-external-rhel8-worker/main.tf
+++ b/tests/standalone-external-rhel8-worker/main.tf
@@ -7,7 +7,7 @@ resource "random_pet" "main" {
 # Store TFE License as secret
 # ---------------------------
 module "secrets" {
-  count  = length(var.license_file) > 0 ? 1 : 0
+  utility_module_test = var.license_file == null
   source = "../../fixtures/secrets"
 
   license = {

--- a/tests/standalone-external-rhel8-worker/main.tf
+++ b/tests/standalone-external-rhel8-worker/main.tf
@@ -7,7 +7,7 @@ resource "random_pet" "main" {
 # Store TFE License as secret
 # ---------------------------
 module "secrets" {
-  count =  length(var.license_file) > 0 ? 1 : 0
+  count  = length(var.license_file) > 0 ? 1 : 0
   source = "../../fixtures/secrets"
 
   license = {

--- a/tests/standalone-external-rhel8-worker/run-tests.sh
+++ b/tests/standalone-external-rhel8-worker/run-tests.sh
@@ -60,7 +60,7 @@ Executing tests with the following configuration:
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && pwd 2> /dev/null; )";
 
 cd $SCRIPT_DIR
-health_check_url=$(terraform output -no-color -raw ptfe_health_check)
+health_check_url=$(terraform output -no-color ptfe_health_check)
 echo "health check url: $health_check_url"
 
 if [[ -z "$skip_init" ]]; then
@@ -70,7 +70,7 @@ if [[ -z "$skip_init" ]]; then
             do sleep 5; done
     echo " : TFE is healthy and listening."
 
-    tfe_url=$(terraform output -no-color -raw ptfe_endpoint)
+    tfe_url=$(terraform output -no-color ptfe_endpoint)
     echo "tfe url: $tfe_url"
     iact_url=$(echo "$tfe_url"admin/retrieve-iact)
     echo "iact url: $iact_url"

--- a/tests/standalone-external-rhel8-worker/variables.tf
+++ b/tests/standalone-external-rhel8-worker/variables.tf
@@ -40,12 +40,6 @@ variable "tfe_hostname" {
   type        = string
 }
 
-variable "tfe_license_secret_id" {
-  default     = null
-  type        = string
-  description = "The Secrets Manager secret ARN under which the Base64 encoded Terraform Enterprise license is stored."
-}
-
 variable "tfe_organization" {
   default     = null
   description = "Organization of the Terraform Enterprise instance which manages the base infrastructure."

--- a/tests/standalone-external-rhel8-worker/versions.tf
+++ b/tests/standalone-external-rhel8-worker/versions.tf
@@ -4,12 +4,12 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.90.1"
+      version = "~> 3.54"
     }
 
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.90.1"
+      version = "~> 3.54"
     }
 
     local = {

--- a/tests/standalone-external-rhel8-worker/versions.tf
+++ b/tests/standalone-external-rhel8-worker/versions.tf
@@ -4,12 +4,12 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.54"
+      version = "~> 3.90"
     }
 
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.54"
+      version = "~> 3.90"
     }
 
     local = {

--- a/tests/standalone-mounted-disk/data.tf
+++ b/tests/standalone-mounted-disk/data.tf
@@ -13,7 +13,7 @@ data "google_compute_image" "ubuntu" {
 }
 
 data "google_compute_region_instance_group" "tfe" {
-  self_link = null_resource.wait_for_instances.triggers.self_link
+  self_link = module.tfe.vm_mig.instance_group
 }
 
 data "google_compute_instance" "tfe" {

--- a/tests/standalone-mounted-disk/locals.tf
+++ b/tests/standalone-mounted-disk/locals.tf
@@ -10,5 +10,4 @@ locals {
     terraform   = "true"
   }
   ssh_user            = "ubuntu"
-  utility_module_test = var.license_file == null
 }

--- a/tests/standalone-mounted-disk/locals.tf
+++ b/tests/standalone-mounted-disk/locals.tf
@@ -9,5 +9,5 @@ locals {
     team        = "terraform-enterprise-on-prem"
     terraform   = "true"
   }
-  ssh_user            = "ubuntu"
+  ssh_user = "ubuntu"
 }

--- a/tests/standalone-mounted-disk/locals.tf
+++ b/tests/standalone-mounted-disk/locals.tf
@@ -10,4 +10,5 @@ locals {
     terraform   = "true"
   }
   ssh_user = "ubuntu"
+  utility_module_test = var.license_file == null
 }

--- a/tests/standalone-mounted-disk/locals.tf
+++ b/tests/standalone-mounted-disk/locals.tf
@@ -9,6 +9,6 @@ locals {
     team        = "terraform-enterprise-on-prem"
     terraform   = "true"
   }
-  ssh_user = "ubuntu"
+  ssh_user            = "ubuntu"
   utility_module_test = var.license_file == null
 }

--- a/tests/standalone-mounted-disk/locals.tf
+++ b/tests/standalone-mounted-disk/locals.tf
@@ -9,6 +9,5 @@ locals {
     team        = "terraform-enterprise-on-prem"
     terraform   = "true"
   }
-  ssh_user            = "ubuntu"
-  utility_module_test = var.license_file == null
+  ssh_user = "ubuntu"
 }

--- a/tests/standalone-mounted-disk/locals.tf
+++ b/tests/standalone-mounted-disk/locals.tf
@@ -9,5 +9,6 @@ locals {
     team        = "terraform-enterprise-on-prem"
     terraform   = "true"
   }
-  ssh_user = "ubuntu"
+  ssh_user            = "ubuntu"
+  utility_module_test = var.license_file == null
 }

--- a/tests/standalone-mounted-disk/main.tf
+++ b/tests/standalone-mounted-disk/main.tf
@@ -35,7 +35,7 @@ module "tfe" {
   fqdn                        = "${random_pet.main.id}.${trimsuffix(data.google_dns_managed_zone.main.dns_name, ".")}"
   namespace                   = random_pet.main.id
   node_count                  = 1
-  tfe_license_secret_id       = try(module.secrets[0].license_secret, var.tfe_license_secret_id, data.tfe_outputs.base.values.license_secret_id)
+  tfe_license_secret_id       = try(module.secrets[0].license_secret, data.tfe_outputs.base.values.license_secret_id)
   ssl_certificate_name        = data.tfe_outputs.base.values.wildcard_ssl_certificate_name
   existing_service_account_id = var.existing_service_account_id
   iact_subnet_list            = ["0.0.0.0/0"]

--- a/tests/standalone-mounted-disk/main.tf
+++ b/tests/standalone-mounted-disk/main.tf
@@ -7,7 +7,7 @@ resource "random_pet" "main" {
 # Store TFE License as secret
 # ---------------------------
 module "secrets" {
-  count  = local.utility_module_test ? 0 : 1
+  count =  length(var.license_file) > 0 ? 1 : 0
   source = "../../fixtures/secrets"
 
   license = {

--- a/tests/standalone-mounted-disk/main.tf
+++ b/tests/standalone-mounted-disk/main.tf
@@ -7,7 +7,7 @@ resource "random_pet" "main" {
 # Store TFE License as secret
 # ---------------------------
 module "secrets" {
-  count  = local.utility_module_test ? 0 : 1
+  count  = length(var.license_file)
   source = "../../fixtures/secrets"
 
   license = {

--- a/tests/standalone-mounted-disk/main.tf
+++ b/tests/standalone-mounted-disk/main.tf
@@ -7,7 +7,7 @@ resource "random_pet" "main" {
 # Store TFE License as secret
 # ---------------------------
 module "secrets" {
-  count  = length(var.license_file)
+  count  = local.utility_module_test ? 0 : 1
   source = "../../fixtures/secrets"
 
   license = {

--- a/tests/standalone-mounted-disk/main.tf
+++ b/tests/standalone-mounted-disk/main.tf
@@ -7,7 +7,7 @@ resource "random_pet" "main" {
 # Store TFE License as secret
 # ---------------------------
 module "secrets" {
-  count  = length(var.license_file) > 0 ? 1 : 0
+  count  = local.utility_module_test ? 0 : 1
   source = "../../fixtures/secrets"
 
   license = {

--- a/tests/standalone-mounted-disk/main.tf
+++ b/tests/standalone-mounted-disk/main.tf
@@ -7,7 +7,7 @@ resource "random_pet" "main" {
 # Store TFE License as secret
 # ---------------------------
 module "secrets" {
-  count =  length(var.license_file) > 0 ? 1 : 0
+  count  = length(var.license_file) > 0 ? 1 : 0
   source = "../../fixtures/secrets"
 
   license = {

--- a/tests/standalone-mounted-disk/run-tests.sh
+++ b/tests/standalone-mounted-disk/run-tests.sh
@@ -60,7 +60,7 @@ Executing tests with the following configuration:
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && pwd 2> /dev/null; )";
 
 cd $SCRIPT_DIR
-health_check_url=$(terraform output -no-color -raw ptfe_health_check)
+health_check_url=$(terraform output -no-color ptfe_health_check)
 echo "health check url: $health_check_url"
 
 if [[ -z "$skip_init" ]]; then
@@ -70,7 +70,7 @@ if [[ -z "$skip_init" ]]; then
             do sleep 5; done
     echo " : TFE is healthy and listening."
 
-    tfe_url=$(terraform output -no-color -raw ptfe_endpoint)
+    tfe_url=$(terraform output -no-color ptfe_endpoint)
     echo "tfe url: $tfe_url"
     iact_url=$(echo "$tfe_url"admin/retrieve-iact)
     echo "iact url: $iact_url"

--- a/tests/standalone-mounted-disk/variables.tf
+++ b/tests/standalone-mounted-disk/variables.tf
@@ -40,12 +40,6 @@ variable "tfe_hostname" {
   type        = string
 }
 
-variable "tfe_license_secret_id" {
-  default     = null
-  type        = string
-  description = "The Secrets Manager secret ARN under which the Base64 encoded Terraform Enterprise license is stored."
-}
-
 variable "tfe_organization" {
   default     = null
   description = "Organization of the Terraform Enterprise instance which manages the base infrastructure."

--- a/tests/standalone-mounted-disk/versions.tf
+++ b/tests/standalone-mounted-disk/versions.tf
@@ -4,12 +4,12 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.90.1"
+      version = "~> 3.54"
     }
 
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.90.1"
+      version = "~> 3.54"
     }
 
     local = {

--- a/tests/standalone-mounted-disk/versions.tf
+++ b/tests/standalone-mounted-disk/versions.tf
@@ -4,12 +4,12 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.54"
+      version = "~> 3.90"
     }
 
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.54"
+      version = "~> 3.90"
     }
 
     local = {


### PR DESCRIPTION
## Background

`var.tfe_license_secret_id` is not used by both ptfe-replicated circle CI and the terraform-random-tfe-utility GHA tests.
license is fetched either from secret fixture module or via TFE provider data block