### PR TITLE
need only for replicated tests

### DIFF
--- a/tests/private-active-active/main.tf
+++ b/tests/private-active-active/main.tf
@@ -21,7 +21,7 @@ module "tfe" {
 
   distribution                = "rhel"
   dns_zone_name               = data.google_dns_managed_zone.main.name
-  fqdn                        = "private-active-active.${data.google_dns_managed_zone.main.dns_name}"
+  fqdn                        = "${random_pet.main.id}.${data.google_dns_managed_zone.main.dns_name}"
   namespace                   = random_pet.main.id
   existing_service_account_id = local.existing_service_account_id
   node_count                  = 2

--- a/tests/private-tcp-active-active/main.tf
+++ b/tests/private-tcp-active-active/main.tf
@@ -23,7 +23,7 @@ module "tfe" {
 
   distribution                = "rhel"
   dns_zone_name               = data.google_dns_managed_zone.main.name
-  fqdn                        = "private-tcp-active-active.${data.google_dns_managed_zone.main.dns_name}"
+  fqdn                        = "${random_pet.main.id}.${data.google_dns_managed_zone.main.dns_name}"
   namespace                   = random_pet.main.id
   existing_service_account_id = local.existing_service_account_id
   node_count                  = 2

--- a/tests/public-active-active/main.tf
+++ b/tests/public-active-active/main.tf
@@ -8,7 +8,7 @@ module "tfe" {
   source = "../.."
 
   dns_zone_name               = data.google_dns_managed_zone.main.name
-  fqdn                        = "public-active-active.${data.google_dns_managed_zone.main.dns_name}"
+  fqdn                        = "${random_pet.main.id}.${data.google_dns_managed_zone.main.dns_name}"
   namespace                   = random_pet.main.id
   existing_service_account_id = local.existing_service_account_id
   node_count                  = 2

--- a/tests/standalone-external-rhel8-worker/data.tf
+++ b/tests/standalone-external-rhel8-worker/data.tf
@@ -14,12 +14,12 @@ data "google_compute_image" "rhel" {
 
 data "google_compute_region_instance_group" "tfe" {
   count     = local.enable_ssh_config
-  self_link = null_resource.wait_for_instances.triggers.self_link
+  self_link = null_resource.wait_for_instances[0].triggers.self_link
 }
 
 data "google_compute_instance" "tfe" {
   count     = local.enable_ssh_config
-  self_link = data.google_compute_region_instance_group.tfe.instances[0].instance
+  self_link = data.google_compute_region_instance_group.tfe[0].instances[0].instance
 }
 
 # This null_data_source is used to prevent Terraform from trying to render local_file.ssh_config file before data.
@@ -28,9 +28,9 @@ data "google_compute_instance" "tfe" {
 data "null_data_source" "instance" {
   count = local.enable_ssh_config
   inputs = {
-    name       = data.google_compute_instance.tfe.name
-    network_ip = data.google_compute_instance.tfe.network_interface[0].network_ip
-    project    = data.google_compute_instance.tfe.project
-    zone       = data.google_compute_instance.tfe.zone
+    name       = data.google_compute_instance.tfe[0].name
+    network_ip = data.google_compute_instance.tfe[0].network_interface[0].network_ip
+    project    = data.google_compute_instance.tfe[0].project
+    zone       = data.google_compute_instance.tfe[0].zone
   }
 }

--- a/tests/standalone-external-rhel8-worker/data.tf
+++ b/tests/standalone-external-rhel8-worker/data.tf
@@ -13,10 +13,12 @@ data "google_compute_image" "rhel" {
 }
 
 data "google_compute_region_instance_group" "tfe" {
+  count  = local.enable_ssh_config
   self_link = null_resource.wait_for_instances.triggers.self_link
 }
 
 data "google_compute_instance" "tfe" {
+  count  = local.enable_ssh_config
   self_link = data.google_compute_region_instance_group.tfe.instances[0].instance
 }
 
@@ -24,6 +26,7 @@ data "google_compute_instance" "tfe" {
 # google_compute_instance.tfe is available.
 # See https://github.com/hashicorp/terraform-provider-local/issues/57
 data "null_data_source" "instance" {
+  count  = local.enable_ssh_config
   inputs = {
     name       = data.google_compute_instance.tfe.name
     network_ip = data.google_compute_instance.tfe.network_interface[0].network_ip

--- a/tests/standalone-external-rhel8-worker/data.tf
+++ b/tests/standalone-external-rhel8-worker/data.tf
@@ -13,12 +13,12 @@ data "google_compute_image" "rhel" {
 }
 
 data "google_compute_region_instance_group" "tfe" {
-  count  = local.enable_ssh_config
+  count     = local.enable_ssh_config
   self_link = null_resource.wait_for_instances.triggers.self_link
 }
 
 data "google_compute_instance" "tfe" {
-  count  = local.enable_ssh_config
+  count     = local.enable_ssh_config
   self_link = data.google_compute_region_instance_group.tfe.instances[0].instance
 }
 
@@ -26,7 +26,7 @@ data "google_compute_instance" "tfe" {
 # google_compute_instance.tfe is available.
 # See https://github.com/hashicorp/terraform-provider-local/issues/57
 data "null_data_source" "instance" {
-  count  = local.enable_ssh_config
+  count = local.enable_ssh_config
   inputs = {
     name       = data.google_compute_instance.tfe.name
     network_ip = data.google_compute_instance.tfe.network_interface[0].network_ip

--- a/tests/standalone-external-rhel8-worker/locals.tf
+++ b/tests/standalone-external-rhel8-worker/locals.tf
@@ -2,4 +2,5 @@ locals {
   repository_location = "us-west1"
   repository_name     = "terraform-build-worker"
   ssh_user            = "ubuntu"
+  enable_ssh_config = length(var.license_file) > 0 ? 1 : 0
 }

--- a/tests/standalone-external-rhel8-worker/locals.tf
+++ b/tests/standalone-external-rhel8-worker/locals.tf
@@ -2,5 +2,5 @@ locals {
   repository_location = "us-west1"
   repository_name     = "terraform-build-worker"
   ssh_user            = "ubuntu"
-  enable_ssh_config = length(var.license_file) > 0 ? 1 : 0
+  enable_ssh_config   = length(var.license_file) > 0 ? 1 : 0
 }

--- a/tests/standalone-external-rhel8-worker/main.tf
+++ b/tests/standalone-external-rhel8-worker/main.tf
@@ -87,7 +87,7 @@ resource "local_file" "ssh_config" {
   content = templatefile(
     "${path.module}/templates/ssh-config.tpl",
     {
-      instance      = data.null_data_source.instance.outputs
+      instance      = data.null_data_source.instance[0].outputs
       identity_file = local_file.private_key_pem.filename
       user          = local.ssh_user
     }

--- a/tests/standalone-external-rhel8-worker/main.tf
+++ b/tests/standalone-external-rhel8-worker/main.tf
@@ -70,6 +70,7 @@ resource "google_artifact_registry_repository_iam_member" "main" {
 }
 
 resource "null_resource" "wait_for_instances" {
+  count  = local.enable_ssh_config
   triggers = {
     self_link = module.tfe.vm_mig.instance_group
   }
@@ -80,6 +81,7 @@ resource "null_resource" "wait_for_instances" {
 }
 
 resource "local_file" "ssh_config" {
+  count  = local.enable_ssh_config
   filename = "${path.module}/work/ssh-config"
 
   content = templatefile(

--- a/tests/standalone-external-rhel8-worker/main.tf
+++ b/tests/standalone-external-rhel8-worker/main.tf
@@ -70,7 +70,7 @@ resource "google_artifact_registry_repository_iam_member" "main" {
 }
 
 resource "null_resource" "wait_for_instances" {
-  count  = local.enable_ssh_config
+  count = local.enable_ssh_config
   triggers = {
     self_link = module.tfe.vm_mig.instance_group
   }
@@ -81,7 +81,7 @@ resource "null_resource" "wait_for_instances" {
 }
 
 resource "local_file" "ssh_config" {
-  count  = local.enable_ssh_config
+  count    = local.enable_ssh_config
   filename = "${path.module}/work/ssh-config"
 
   content = templatefile(

--- a/tests/standalone-external-rhel8-worker/outputs.tf
+++ b/tests/standalone-external-rhel8-worker/outputs.tf
@@ -20,7 +20,7 @@ output "health_check_url" {
 }
 
 output "ssh_config_file" {
-  value = local_file.ssh_config.filename
+  value = local_file.ssh_config[0].filename
 
   description = "The pathname of the SSH configuration file that grants access to the compute instance."
 }

--- a/tests/standalone-external-rhel8-worker/outputs.tf
+++ b/tests/standalone-external-rhel8-worker/outputs.tf
@@ -20,13 +20,13 @@ output "health_check_url" {
 }
 
 output "ssh_config_file" {
-  value = local.enable_ssh_config ? "To connect to your instance, use the SSH button in the console" : local_file.ssh_config[0].filename
+  value = local.enable_ssh_config != 1 ? "To connect to your instance, use the SSH button in the console" : local_file.ssh_config[0].filename
 
   description = "The pathname of the SSH configuration file that grants access to the compute instance."
 }
 
 output "ssh_private_key" {
-  value = local.enable_ssh_config ? "To connect to your instance, use the SSH button in the console" : local_file.private_key_pem.filename
+  value = local.enable_ssh_config != 1 ? "To connect to your instance, use the SSH button in the console" : local_file.private_key_pem.filename
 
   description = "The pathname of the private SSH key."
 }

--- a/tests/standalone-external-rhel8-worker/outputs.tf
+++ b/tests/standalone-external-rhel8-worker/outputs.tf
@@ -20,13 +20,13 @@ output "health_check_url" {
 }
 
 output "ssh_config_file" {
-  value = local_file.ssh_config[0].filename
+  value = local.enable_ssh_config ? "To connect to your instance, use the SSH button in the console" : local_file.ssh_config[0].filename
 
   description = "The pathname of the SSH configuration file that grants access to the compute instance."
 }
 
 output "ssh_private_key" {
-  value = local_file.private_key_pem.filename
+  value = local.enable_ssh_config ? "To connect to your instance, use the SSH button in the console" : local_file.private_key_pem.filename
 
   description = "The pathname of the private SSH key."
 }

--- a/tests/standalone-mounted-disk/data.tf
+++ b/tests/standalone-mounted-disk/data.tf
@@ -14,12 +14,12 @@ data "google_compute_image" "ubuntu" {
 
 data "google_compute_region_instance_group" "tfe" {
   count     = local.enable_ssh_config
-  self_link = null_resource.wait_for_instances.triggers.self_link
+  self_link = null_resource.wait_for_instances[count.index].triggers.self_link
 }
 
 data "google_compute_instance" "tfe" {
   count     = local.enable_ssh_config
-  self_link = data.google_compute_region_instance_group.tfe.instances[0].instance
+  self_link = data.google_compute_region_instance_group.tfe[count.index].instances[0].instance
 }
 
 # This null_data_source is used to prevent Terraform from trying to render local_file.ssh_config file before data.
@@ -28,9 +28,9 @@ data "google_compute_instance" "tfe" {
 data "null_data_source" "instance" {
   count = local.enable_ssh_config
   inputs = {
-    name       = data.google_compute_instance.tfe.name
-    network_ip = data.google_compute_instance.tfe.network_interface[0].network_ip
-    project    = data.google_compute_instance.tfe.project
-    zone       = data.google_compute_instance.tfe.zone
+    name       = data.google_compute_instance.tfe[0].name
+    network_ip = data.google_compute_instance.tfe[0].network_interface[0].network_ip
+    project    = data.google_compute_instance.tfe[0].project
+    zone       = data.google_compute_instance.tfe[0].zone
   }
 }

--- a/tests/standalone-mounted-disk/data.tf
+++ b/tests/standalone-mounted-disk/data.tf
@@ -13,12 +13,12 @@ data "google_compute_image" "ubuntu" {
 }
 
 data "google_compute_region_instance_group" "tfe" {
-  count  = local.enable_ssh_config
+  count     = local.enable_ssh_config
   self_link = null_resource.wait_for_instances.triggers.self_link
 }
 
 data "google_compute_instance" "tfe" {
-  count  = local.enable_ssh_config
+  count     = local.enable_ssh_config
   self_link = data.google_compute_region_instance_group.tfe.instances[0].instance
 }
 
@@ -26,7 +26,7 @@ data "google_compute_instance" "tfe" {
 # google_compute_instance.tfe is available.
 # See https://github.com/hashicorp/terraform-provider-local/issues/57
 data "null_data_source" "instance" {
-  count  = local.enable_ssh_config
+  count = local.enable_ssh_config
   inputs = {
     name       = data.google_compute_instance.tfe.name
     network_ip = data.google_compute_instance.tfe.network_interface[0].network_ip

--- a/tests/standalone-mounted-disk/data.tf
+++ b/tests/standalone-mounted-disk/data.tf
@@ -13,10 +13,12 @@ data "google_compute_image" "ubuntu" {
 }
 
 data "google_compute_region_instance_group" "tfe" {
+  count  = local.enable_ssh_config
   self_link = null_resource.wait_for_instances.triggers.self_link
 }
 
 data "google_compute_instance" "tfe" {
+  count  = local.enable_ssh_config
   self_link = data.google_compute_region_instance_group.tfe.instances[0].instance
 }
 
@@ -24,6 +26,7 @@ data "google_compute_instance" "tfe" {
 # google_compute_instance.tfe is available.
 # See https://github.com/hashicorp/terraform-provider-local/issues/57
 data "null_data_source" "instance" {
+  count  = local.enable_ssh_config
   inputs = {
     name       = data.google_compute_instance.tfe.name
     network_ip = data.google_compute_instance.tfe.network_interface[0].network_ip

--- a/tests/standalone-mounted-disk/locals.tf
+++ b/tests/standalone-mounted-disk/locals.tf
@@ -10,4 +10,5 @@ locals {
     terraform   = "true"
   }
   ssh_user = "ubuntu"
+  enable_ssh_config = length(var.license_file) > 0 ? 1 : 0
 }

--- a/tests/standalone-mounted-disk/locals.tf
+++ b/tests/standalone-mounted-disk/locals.tf
@@ -9,6 +9,6 @@ locals {
     team        = "terraform-enterprise-on-prem"
     terraform   = "true"
   }
-  ssh_user = "ubuntu"
+  ssh_user          = "ubuntu"
   enable_ssh_config = length(var.license_file) > 0 ? 1 : 0
 }

--- a/tests/standalone-mounted-disk/main.tf
+++ b/tests/standalone-mounted-disk/main.tf
@@ -68,7 +68,7 @@ resource "local_file" "ssh_config" {
   content = templatefile(
     "${path.module}/templates/ssh-config.tpl",
     {
-      instance      = data.null_data_source.instance.outputs
+      instance      = data.null_data_source.instance[0].outputs
       identity_file = local_file.private_key_pem.filename
       user          = local.ssh_user
     }

--- a/tests/standalone-mounted-disk/main.tf
+++ b/tests/standalone-mounted-disk/main.tf
@@ -51,6 +51,7 @@ module "tfe" {
 }
 
 resource "null_resource" "wait_for_instances" {
+  count  = local.enable_ssh_config
   triggers = {
     self_link = module.tfe.vm_mig.instance_group
   }
@@ -61,6 +62,7 @@ resource "null_resource" "wait_for_instances" {
 }
 
 resource "local_file" "ssh_config" {
+  count  = local.enable_ssh_config
   filename = "${path.module}/work/ssh-config"
 
   content = templatefile(

--- a/tests/standalone-mounted-disk/main.tf
+++ b/tests/standalone-mounted-disk/main.tf
@@ -51,7 +51,7 @@ module "tfe" {
 }
 
 resource "null_resource" "wait_for_instances" {
-  count  = local.enable_ssh_config
+  count = local.enable_ssh_config
   triggers = {
     self_link = module.tfe.vm_mig.instance_group
   }
@@ -62,7 +62,7 @@ resource "null_resource" "wait_for_instances" {
 }
 
 resource "local_file" "ssh_config" {
-  count  = local.enable_ssh_config
+  count    = local.enable_ssh_config
   filename = "${path.module}/work/ssh-config"
 
   content = templatefile(

--- a/tests/standalone-mounted-disk/outputs.tf
+++ b/tests/standalone-mounted-disk/outputs.tf
@@ -20,7 +20,7 @@ output "health_check_url" {
 }
 
 output "ssh_config_file" {
-  value = local_file.ssh_config.filename
+  value = local_file.ssh_config[0].filename
 
   description = "The pathname of the SSH configuration file that grants access to the compute instance."
 }

--- a/tests/standalone-mounted-disk/outputs.tf
+++ b/tests/standalone-mounted-disk/outputs.tf
@@ -20,13 +20,13 @@ output "health_check_url" {
 }
 
 output "ssh_config_file" {
-  value = local.enable_ssh_config ? "To connect to your instance, use the SSH button in the console" : local_file.ssh_config[0].filename
+  value = local.enable_ssh_config != 1 ? "To connect to your instance, use the SSH button in the console" : local_file.ssh_config[0].filename
 
   description = "The pathname of the SSH configuration file that grants access to the compute instance."
 }
 
 output "ssh_private_key" {
-  value = local.enable_ssh_config ? "To connect to your instance, use the SSH button in the console" : local_file.private_key_pem.filename
+  value = local.enable_ssh_config != 1 ? "To connect to your instance, use the SSH button in the console" : local_file.private_key_pem.filename
 
   description = "The pathname of the private SSH key."
 }

--- a/tests/standalone-mounted-disk/outputs.tf
+++ b/tests/standalone-mounted-disk/outputs.tf
@@ -20,13 +20,13 @@ output "health_check_url" {
 }
 
 output "ssh_config_file" {
-  value = local_file.ssh_config[0].filename
+  value = local.enable_ssh_config ? "To connect to your instance, use the SSH button in the console" : local_file.ssh_config[0].filename
 
   description = "The pathname of the SSH configuration file that grants access to the compute instance."
 }
 
 output "ssh_private_key" {
-  value = local_file.private_key_pem.filename
+  value = local.enable_ssh_config ? "To connect to your instance, use the SSH button in the console" : local_file.private_key_pem.filename
 
   description = "The pathname of the private SSH key."
 }


### PR DESCRIPTION
## Background

ssh_config needed only for replicated tests
unique dns names