### PR TITLE
update

### DIFF
--- a/tests/private-active-active/main.tf
+++ b/tests/private-active-active/main.tf
@@ -19,7 +19,7 @@ module "test_proxy" {
 # Store TFE License as secret
 # ---------------------------
 module "secrets" {
-  count  = length(var.license_file) > 0 ? 1 : 0
+  count  = var.license_file != null ? 1 : 0
   source = "../../fixtures/secrets"
 
   license = {

--- a/tests/private-active-active/main.tf
+++ b/tests/private-active-active/main.tf
@@ -16,6 +16,18 @@ module "test_proxy" {
   labels = local.labels
 }
 
+# Store TFE License as secret
+# ---------------------------
+module "secrets" {
+  count  = length(var.license_file) > 0 ? 1 : 0
+  source = "../../fixtures/secrets"
+
+  license = {
+    id   = random_pet.main.id
+    path = var.license_file
+  }
+}
+
 module "tfe" {
   source = "../.."
 
@@ -25,7 +37,7 @@ module "tfe" {
   namespace                   = random_pet.main.id
   existing_service_account_id = local.existing_service_account_id
   node_count                  = 2
-  tfe_license_secret_id       = data.tfe_outputs.base.values.license_secret_id
+  tfe_license_secret_id       = try(module.secrets[0].license_secret, data.tfe_outputs.base.values.license_secret_id)
   ssl_certificate_name        = data.tfe_outputs.base.values.wildcard_region_ssl_certificate_name
   labels                      = local.labels
   iact_subnet_list            = ["${module.test_proxy.compute_instance.network_interface[0].network_ip}/32"]

--- a/tests/private-active-active/main.tf
+++ b/tests/private-active-active/main.tf
@@ -20,7 +20,7 @@ module "test_proxy" {
 # ---------------------------
 module "secrets" {
   count  = length(var.license_file) > 0 ? 1 : 0
-  source = "${path.root}/fixtures/secrets"
+  source = "../../fixtures/secrets"
 
   license = {
     id   = random_pet.main.id

--- a/tests/private-active-active/main.tf
+++ b/tests/private-active-active/main.tf
@@ -20,7 +20,7 @@ module "test_proxy" {
 # ---------------------------
 module "secrets" {
   count  = length(var.license_file) > 0 ? 1 : 0
-  source = "../../fixtures/secrets"
+  source = "${path.root}/fixtures/secrets"
 
   license = {
     id   = random_pet.main.id

--- a/tests/private-active-active/variables.tf
+++ b/tests/private-active-active/variables.tf
@@ -1,3 +1,9 @@
+variable "existing_service_account_id" {
+  default     = null
+  type        = string
+  description = "The id of the logging service account to use for compute resources deployed."
+}
+
 variable "google" {
   default     = null
   description = "Attributes of the Google Cloud account which will host the test infrastructure."
@@ -34,6 +40,12 @@ variable "google_zone" {
   type        = string
 }
 
+variable "license_file" {
+  default     = null
+  type        = string
+  description = "The local path to the Terraform Enterprise license to be provided by CI."
+}
+
 variable "tfe_hostname" {
   default     = null
   description = "Hostname of the Terraform Enterprise instance which manages the base infrastructure."
@@ -67,10 +79,4 @@ variable "tfe" {
     token        = string
     workspace    = string
   })
-}
-
-variable "existing_service_account_id" {
-  default     = null
-  type        = string
-  description = "The id of the logging service account to use for compute resources deployed."
 }

--- a/tests/private-active-active/versions.tf
+++ b/tests/private-active-active/versions.tf
@@ -22,12 +22,4 @@ terraform {
       version = "~> 0.26"
     }
   }
-
-  backend "remote" {
-    organization = "terraform-enterprise-modules-test"
-
-    workspaces {
-      name = "google-private-active-active"
-    }
-  }
 }

--- a/tests/private-tcp-active-active/main.tf
+++ b/tests/private-tcp-active-active/main.tf
@@ -21,7 +21,7 @@ module "test_proxy" {
 # Store TFE License as secret
 # ---------------------------
 module "secrets" {
-  count  = length(var.license_file) > 0 ? 1 : 0
+  count  = var.license_file != null ? 1 : 0
   source = "../../fixtures/secrets"
 
   license = {

--- a/tests/private-tcp-active-active/main.tf
+++ b/tests/private-tcp-active-active/main.tf
@@ -22,7 +22,7 @@ module "test_proxy" {
 # ---------------------------
 module "secrets" {
   count  = length(var.license_file) > 0 ? 1 : 0
-  source = "${path.root}/fixtures/secrets"
+  source = "../../fixtures/secrets"
 
   license = {
     id   = random_pet.main.id

--- a/tests/private-tcp-active-active/main.tf
+++ b/tests/private-tcp-active-active/main.tf
@@ -22,7 +22,7 @@ module "test_proxy" {
 # ---------------------------
 module "secrets" {
   count  = length(var.license_file) > 0 ? 1 : 0
-  source = "../../fixtures/secrets"
+  source = "${path.root}/fixtures/secrets"
 
   license = {
     id   = random_pet.main.id

--- a/tests/private-tcp-active-active/main.tf
+++ b/tests/private-tcp-active-active/main.tf
@@ -18,6 +18,18 @@ module "test_proxy" {
   mitmproxy_ca_private_key_secret = data.tfe_outputs.base.values.ca_private_key_secret_id
 }
 
+# Store TFE License as secret
+# ---------------------------
+module "secrets" {
+  count  = length(var.license_file) > 0 ? 1 : 0
+  source = "../../fixtures/secrets"
+
+  license = {
+    id   = random_pet.main.id
+    path = var.license_file
+  }
+}
+
 module "tfe" {
   source = "../.."
 
@@ -27,7 +39,7 @@ module "tfe" {
   namespace                   = random_pet.main.id
   existing_service_account_id = local.existing_service_account_id
   node_count                  = 2
-  tfe_license_secret_id       = data.tfe_outputs.base.values.license_secret_id
+  tfe_license_secret_id       = try(module.secrets[0].license_secret, data.tfe_outputs.base.values.license_secret_id)
   labels                      = local.labels
   ca_certificate_secret_id    = data.tfe_outputs.base.values.ca_certificate_secret_id
   iact_subnet_list            = ["${module.test_proxy.compute_instance.network_interface[0].network_ip}/32"]

--- a/tests/private-tcp-active-active/variables.tf
+++ b/tests/private-tcp-active-active/variables.tf
@@ -1,3 +1,9 @@
+variable "existing_service_account_id" {
+  default     = null
+  type        = string
+  description = "The id of the logging service account to use for compute resources deployed."
+}
+
 variable "google" {
   default     = null
   description = "Attributes of the Google Cloud account which will host the test infrastructure."
@@ -34,6 +40,12 @@ variable "google_zone" {
   type        = string
 }
 
+variable "license_file" {
+  default     = null
+  type        = string
+  description = "The local path to the Terraform Enterprise license to be provided by CI."
+}
+
 variable "tfe_hostname" {
   default     = null
   description = "Hostname of the Terraform Enterprise instance which manages the base infrastructure."
@@ -67,10 +79,4 @@ variable "tfe" {
     token        = string
     workspace    = string
   })
-}
-
-variable "existing_service_account_id" {
-  default     = null
-  type        = string
-  description = "The id of the logging service account to use for compute resources deployed."
 }

--- a/tests/private-tcp-active-active/versions.tf
+++ b/tests/private-tcp-active-active/versions.tf
@@ -22,12 +22,4 @@ terraform {
       version = "~> 0.26"
     }
   }
-
-  backend "remote" {
-    organization = "terraform-enterprise-modules-test"
-
-    workspaces {
-      name = "google-private-tcp-active-active"
-    }
-  }
 }

--- a/tests/public-active-active/main.tf
+++ b/tests/public-active-active/main.tf
@@ -7,7 +7,7 @@ resource "random_pet" "main" {
 # Store TFE License as secret
 # ---------------------------
 module "secrets" {
-  count  = length(var.license_file) > 0 ? 1 : 0
+  count  = var.license_file != null ? 1 : 0
   source = "../../fixtures/secrets"
 
   license = {

--- a/tests/public-active-active/main.tf
+++ b/tests/public-active-active/main.tf
@@ -8,7 +8,7 @@ resource "random_pet" "main" {
 # ---------------------------
 module "secrets" {
   count  = length(var.license_file) > 0 ? 1 : 0
-  source = "${path.root}/fixtures/secrets"
+  source = "../../fixtures/secrets"
 
   license = {
     id   = random_pet.main.id

--- a/tests/public-active-active/main.tf
+++ b/tests/public-active-active/main.tf
@@ -8,7 +8,7 @@ resource "random_pet" "main" {
 # ---------------------------
 module "secrets" {
   count  = length(var.license_file) > 0 ? 1 : 0
-  source = "../../fixtures/secrets"
+  source = "${path.root}/fixtures/secrets"
 
   license = {
     id   = random_pet.main.id

--- a/tests/public-active-active/main.tf
+++ b/tests/public-active-active/main.tf
@@ -4,6 +4,18 @@ resource "random_pet" "main" {
   separator = "-"
 }
 
+# Store TFE License as secret
+# ---------------------------
+module "secrets" {
+  count  = length(var.license_file) > 0 ? 1 : 0
+  source = "../../fixtures/secrets"
+
+  license = {
+    id   = random_pet.main.id
+    path = var.license_file
+  }
+}
+
 module "tfe" {
   source = "../.."
 
@@ -12,7 +24,7 @@ module "tfe" {
   namespace                   = random_pet.main.id
   existing_service_account_id = local.existing_service_account_id
   node_count                  = 2
-  tfe_license_secret_id       = data.tfe_outputs.base.values.license_secret_id
+  tfe_license_secret_id       = try(module.secrets[0].license_secret, data.tfe_outputs.base.values.license_secret_id)
   ssl_certificate_name        = data.tfe_outputs.base.values.wildcard_ssl_certificate_name
   distribution                = "ubuntu"
   iact_subnet_list            = var.iact_subnet_list

--- a/tests/public-active-active/variables.tf
+++ b/tests/public-active-active/variables.tf
@@ -1,3 +1,9 @@
+variable "existing_service_account_id" {
+  default     = null
+  type        = string
+  description = "The id of the logging service account to use for compute resources deployed."
+}
+
 variable "google" {
   default     = null
   description = "Attributes of the Google Cloud account which will host the test infrastructure."
@@ -43,6 +49,12 @@ variable "iact_subnet_list" {
   type        = list(string)
 }
 
+variable "license_file" {
+  default     = null
+  type        = string
+  description = "The local path to the Terraform Enterprise license to be provided by CI."
+}
+
 variable "tfe_hostname" {
   default     = null
   description = "Hostname of the Terraform Enterprise instance which manages the base infrastructure."
@@ -78,8 +90,3 @@ variable "tfe" {
   })
 }
 
-variable "existing_service_account_id" {
-  default     = null
-  type        = string
-  description = "The id of the logging service account to use for compute resources deployed."
-}

--- a/tests/public-active-active/versions.tf
+++ b/tests/public-active-active/versions.tf
@@ -22,12 +22,4 @@ terraform {
       version = "~> 0.26"
     }
   }
-
-  backend "remote" {
-    organization = "terraform-enterprise-modules-test"
-
-    workspaces {
-      name = "google-public-active-active"
-    }
-  }
 }


### PR DESCRIPTION
## Background

Adding license as a secret-fixture so that we can provide license file from a local path too.
Applicable for invocations from [tf-onprem-dev-infra](https://github.com/hashicorp/tf-onprem-dev-infra)