### PR TITLE
adding missing metrics config varliables

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -104,17 +104,19 @@ module "settings" {
   source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/settings?ref=main"
 
   # TFE Base Configuration
-  production_type          = var.operational_mode
-  disk_path                = var.disk_path
-  iact_subnet_list         = var.iact_subnet_list
-  iact_subnet_time_limit   = var.iact_subnet_time_limit
-  release_sequence         = var.release_sequence
-  tls_vers                 = var.tls_vers
-  metrics_endpoint_enabled = var.metrics_endpoint_enabled
-  custom_image_tag         = var.custom_image_tag
-  capacity_concurrency     = var.capacity_concurrency
-  capacity_memory          = var.capacity_memory
-  tbw_image                = var.tbw_image
+  production_type             = var.operational_mode
+  disk_path                   = var.disk_path
+  iact_subnet_list            = var.iact_subnet_list
+  iact_subnet_time_limit      = var.iact_subnet_time_limit
+  release_sequence            = var.release_sequence
+  tls_vers                    = var.tls_vers
+  metrics_endpoint_enabled    = var.metrics_endpoint_enabled
+  metrics_endpoint_port_http  = var.metrics_endpoint_port_http
+  metrics_endpoint_port_https = var.metrics_endpoint_port_https
+  custom_image_tag            = var.custom_image_tag
+  capacity_concurrency        = var.capacity_concurrency
+  capacity_memory             = var.capacity_memory
+  tbw_image                   = var.tbw_image
 
   extra_no_proxy = concat([
     local.common_fqdn,

--- a/variables.tf
+++ b/variables.tf
@@ -332,6 +332,26 @@ variable "metrics_endpoint_enabled" {
   EOD
 }
 
+variable "metrics_endpoint_port_http" {
+  default     = null
+  type        = number
+  description = <<-EOD
+  (Optional when metrics_endpoint_enabled is true.) Defines the TCP port on which HTTP metrics
+  requests will be handled.
+  Defaults to 9090.
+  EOD
+}
+
+variable "metrics_endpoint_port_https" {
+  default     = null
+  type        = string
+  description = <<-EOD
+  (Optional when metrics_endpoint_enabled is true.) Defines the TCP port on which HTTPS metrics
+  requests will be handled.
+  Defaults to 9091.
+  EOD
+}
+
 variable "operational_mode" {
   default     = "external"
   description = <<-EOD


### PR DESCRIPTION
## Background

This change adds missing configuration options for TFE metrics that are present in other cloud implementations.


## How Has This Been Tested

This change will be tested with the standard /test targets.


## This PR makes me feel

<img src="https://media3.giphy.com/media/xT9C25UNTwfZuk85WP/giphy-downsized-medium.gif"/>
