### PR TITLE
Add Compute Engine API to list of minimum APIs to enable on project

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -7,6 +7,7 @@ module "project_factory_project_services" {
   activate_apis = compact([
     "iam.googleapis.com",
     "logging.googleapis.com",
+    "compute.googleapis.com",
     (local.enable_database_module ? "sqladmin.googleapis.com" : null),
     (local.enable_networking_module ? "networkmanagement.googleapis.com" : null),
     (local.enable_networking_module ? "servicenetworking.googleapis.com" : null),


### PR DESCRIPTION
## Background

Please include a one or two sentence description of what you're changing and why.

- This PR adds the Compute Engine API in the `activate_apis` variable that is passed into the `project_factory_project_services` module.
- Compute Engine API is required for the VM MIG, Image hosting and various other tasks.

Relates OR Closes #0000


## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Ran terraform `plan` on a fresh GCP project, and it would throw an error when attempting to read `data.google_compute_zones.available`, with the following: `Error: googleapi: Error 403: Compute Engine API has not been used in project ...`

### Test Configuration

* Terraform Version: 1.2.8
* Any additional relevant variables: A blank GCP project with no APIs enabled

## This PR makes me feel

![optional gif describing your feelings about this pr](https://i.imgur.com/3cu161a.gif)
