### PR TITLE
add root_password to db

### DIFF
--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -5,6 +5,7 @@ resource "random_pet" "postgres" {
 resource "google_sql_database_instance" "tfe" {
   name             = "${var.namespace}-tfe-${random_pet.postgres.id}"
   database_version = var.postgres_version
+  root_password    = random_string.postgres_password.result
 
   settings {
     tier              = var.machine_type


### PR DESCRIPTION
## Background

I was getting an error that the root_password was required, so I added it here.

## How Has This Been Tested

I ran this in another workspace, but I will test here, too.
