### PR TITLE
Using a project reference to generalize the running environment for the rhel8 worker test

### DIFF
--- a/tests/standalone-external-rhel8-worker/data.tf
+++ b/tests/standalone-external-rhel8-worker/data.tf
@@ -6,6 +6,8 @@ data "tfe_outputs" "base" {
   workspace    = try(var.tfe.workspace, var.tfe_workspace)
 }
 
+data "google_project" "project" {}
+
 data "google_dns_managed_zone" "main" {
   name = data.tfe_outputs.base.values.cloud_dns_name
 }

--- a/tests/standalone-external-rhel8-worker/locals.tf
+++ b/tests/standalone-external-rhel8-worker/locals.tf
@@ -10,5 +10,5 @@ locals {
     "hc-50fbe27799384c96925f18084d7" = "us-west1"
     "tfe-modules-ci-001"             = "us-east4"
   }
-  repository_location = project_regions[data.google_project.project.project_id]
+  repository_location = local.project_regions[data.google_project.project.project_id]
 }

--- a/tests/standalone-external-rhel8-worker/locals.tf
+++ b/tests/standalone-external-rhel8-worker/locals.tf
@@ -7,8 +7,8 @@ locals {
   enable_ssh_config = length(var.license_file) > 0 ? 1 : 0
 
   project_regions = {
-    "hc-50fbe27799384c96925f18084d7" = "us-west1"
-    "tfe-modules-ci-001"             = "us-east4"
+    "ptfe-replicated-ci" = "us-west1"
+    "tfe-modules-ci"     = "us-east4"
   }
   repository_location = local.project_regions[data.google_project.project.project_id]
 }

--- a/tests/standalone-external-rhel8-worker/locals.tf
+++ b/tests/standalone-external-rhel8-worker/locals.tf
@@ -7,8 +7,8 @@ locals {
   enable_ssh_config = length(var.license_file) > 0 ? 1 : 0
 
   project_regions = {
-    "hc-50fbe27799384c96925f18084d7" = "us-west1"
-    "tfe-modules-ci-001"             = "us-east4"
+    "ptfe-replicated-ci" = "us-west1"
+    "tfe-modules-ci"     = "us-east4"
   }
-  repository_location = local.project_regions[data.google_project.project.project_id]
+  repository_location = local.project_regions[data.google_project.project.id]
 }

--- a/tests/standalone-external-rhel8-worker/locals.tf
+++ b/tests/standalone-external-rhel8-worker/locals.tf
@@ -7,8 +7,8 @@ locals {
   enable_ssh_config = length(var.license_file) > 0 ? 1 : 0
 
   project_regions = {
-    "ptfe-replicated-ci" = "us-west1"
-    "tfe-modules-ci"     = "us-east4"
+    "hc-50fbe27799384c96925f18084d7" = "us-west1"
+    "tfe-modules-ci-001"             = "us-east4"
   }
   repository_location = local.project_regions[data.google_project.project.project_id]
 }

--- a/tests/standalone-external-rhel8-worker/locals.tf
+++ b/tests/standalone-external-rhel8-worker/locals.tf
@@ -2,8 +2,13 @@
 # SPDX-License-Identifier: MPL-2.0
 
 locals {
-  repository_location = "us-west1"
-  repository_name     = "terraform-build-worker"
-  ssh_user            = "ubuntu"
-  enable_ssh_config   = length(var.license_file) > 0 ? 1 : 0
+  repository_name   = "terraform-build-worker"
+  ssh_user          = "ubuntu"
+  enable_ssh_config = length(var.license_file) > 0 ? 1 : 0
+
+  project_regions = {
+    "hc-50fbe27799384c96925f18084d7" = "us-west1"
+    "tfe-modules-ci-001"             = "us-east4"
+  }
+  repository_location = project_regions[data.google_project.project.project_id]
 }

--- a/tests/standalone-external-rhel8-worker/locals.tf
+++ b/tests/standalone-external-rhel8-worker/locals.tf
@@ -7,8 +7,8 @@ locals {
   enable_ssh_config = length(var.license_file) > 0 ? 1 : 0
 
   project_regions = {
-    "ptfe-replicated-ci" = "us-west1"
-    "tfe-modules-ci"     = "us-east4"
+    "hc-50fbe27799384c96925f18084d7" = "us-west1"
+    "tfe-modules-ci-001"             = "us-east4"
   }
-  repository_location = local.project_regions[data.google_project.project.id]
+  repository_location = local.project_regions[data.google_project.project.project_id]
 }

--- a/tests/standalone-external-rhel8-worker/main.tf
+++ b/tests/standalone-external-rhel8-worker/main.tf
@@ -30,8 +30,6 @@ resource "local_file" "private_key_pem" {
   file_permission = "0600"
 }
 
-data "google_project" "project" {}
-
 module "tfe" {
   source = "../.."
 

--- a/tests/standalone-external-rhel8-worker/main.tf
+++ b/tests/standalone-external-rhel8-worker/main.tf
@@ -48,13 +48,12 @@ module "tfe" {
   iact_subnet_time_limit      = 60
   labels = {
     department  = "engineering"
-    description = "standalone-external-services-scenario-deployed-from-circleci"
+    description = "standalone-external-services-scenario-deployed-from-gha"
     environment = random_pet.main.id
     oktodelete  = "true"
     product     = "terraform-enterprise"
     repository  = "hashicorp-terraform-google-terraform-enterprise"
     team        = "terraform-enterprise-on-prem"
-    terraform   = "true"
   }
   load_balancer        = "PUBLIC"
   operational_mode     = "external"

--- a/tests/standalone-external-rhel8-worker/main.tf
+++ b/tests/standalone-external-rhel8-worker/main.tf
@@ -30,6 +30,8 @@ resource "local_file" "private_key_pem" {
   file_permission = "0600"
 }
 
+data "google_project" "project" {}
+
 module "tfe" {
   source = "../.."
 
@@ -41,7 +43,7 @@ module "tfe" {
   tfe_license_secret_id       = try(module.secrets[0].license_secret, data.tfe_outputs.base.values.license_secret_id)
   ssl_certificate_name        = data.tfe_outputs.base.values.wildcard_ssl_certificate_name
   existing_service_account_id = var.existing_service_account_id
-  custom_image_tag            = "${local.repository_location}-docker.pkg.dev/ptfe-replicated-ci/${local.repository_name}/rhel-7.9:latest"
+  custom_image_tag            = "${local.repository_location}-docker.pkg.dev/${data.google_project.project.project_id}/${local.repository_name}/rhel-7.9:latest"
   iact_subnet_list            = ["0.0.0.0/0"]
   iact_subnet_time_limit      = 60
   labels = {


### PR DESCRIPTION


## Background

#231 attempted to change the id of the gcp artifact registry to correct recent test failures but it failed, possibly because it targeted a registry in yet another project from the `slash` command tests in the PR.  This change makes the source project dynamic and based on the runtime gcp project id.

## This PR makes me feel

<img src="https://media4.giphy.com/media/rtr4SdtSxbWXm/giphy.gif"/>
