### PR TITLE
test

### DIFF
--- a/.github/workflows/handler-destroy.yml
+++ b/.github/workflows/handler-destroy.yml
@@ -45,32 +45,14 @@ jobs:
           sed --in-place "s/source = \"..\/..\/fixtures\/test_proxy\"/source = \"github.com\/$LOGIN\/$NAME\/\/fixtures\/test_proxy?ref=$SHA\"/" main.tf
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v2
         with:
           cli_config_credentials_hostname: 'app.terraform.io'
           cli_config_credentials_token: ${{ secrets.TFC_TOKEN }}
-          terraform_version: 1.0.11
-          terraform_wrapper: false
+          terraform_version: 1.1.7
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@62d4898025f6041e16b1068643bfc5a696863587 # v1.1.0
-        with:
-          project_id: ${{ secrets.GOOGLE_PROJECT }}
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-          export_default_credentials: true
-
-      - name: Configure Terraform Backend
-        id: backend-config
-        working-directory: ${{ env.WORK_DIR_PATH }}
-        env:
-          TFC_ORGANIZATION: ${{ secrets.TFC_ORGANIZATION }}
-        run: |
-          cat <<EOF > backend-config.hcl
-            organization = "$TFC_ORGANIZATION"
-            workspaces {
-              name = "google-public-active-active-${{ github.event.client_payload.github.payload.issue.number }}"
-            }
-          EOF
 
       - name: Terraform Init
         id: init
@@ -79,20 +61,15 @@ jobs:
 
       - name: Write Terraform Variables
         working-directory: ${{ env.WORK_DIR_PATH }}
-        env:
-          GOOGLE_SERVICE_ACCOUNT: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
-          TFE_HOSTNAME: ${{ secrets.TFE_HOSTNAME }}
-          TFE_ORGANIZATION: ${{ secrets.TFE_ORGANIZATION }}
-          TFE_TOKEN: ${{ secrets.TFE_TOKEN }}
-          TFE_WORKSPACE: ${{ secrets.TFE_WORKSPACE }}
         run: |
           cat <<EOF > github.auto.tfvars
-          existing_service_account_id = "$GOOGLE_SERVICE_ACCOUNT"
+          iact_subnet_list = ["( dig +short @resolver1.opendns.com myip.opendns.com )/32"]
+          existing_service_account_id = "${{ secrets.GOOGLE_SERVICE_ACCOUNT }}"
           tfe = {
-            hostname     = "$TFE_HOSTNAME"
-            organization = "$TFE_ORGANIZATION"
-            token        = "$TFE_TOKEN"
-            workspace    = "$TFE_WORKSPACE"
+            hostname     = "${{ secrets.TFE_HOSTNAME }}"
+            organization = "${{ secrets.TFE_ORGANIZATION }}"
+            token        = "${{ secrets.TFE_TOKEN }}"
+            workspace    = "${{ secrets.TFE_WORKSPACE }}"
           }
           EOF
 
@@ -150,32 +127,14 @@ jobs:
           sed --in-place "s/source = \"..\/..\/fixtures\/test_proxy\"/source = \"github.com\/$LOGIN\/$NAME\/\/fixtures\/test_proxy?ref=$SHA\"/" main.tf
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v2
         with:
           cli_config_credentials_hostname: 'app.terraform.io'
           cli_config_credentials_token: ${{ secrets.TFC_TOKEN }}
-          terraform_version: 1.0.11
-          terraform_wrapper: false
+          terraform_version: 1.1.7
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@62d4898025f6041e16b1068643bfc5a696863587 # v1.1.0
-        with:
-          project_id: ${{ secrets.GOOGLE_PROJECT }}
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-          export_default_credentials: true
-
-      - name: Configure Terraform Backend
-        id: backend-config
-        working-directory: ${{ env.WORK_DIR_PATH }}
-        env:
-          TFC_ORGANIZATION: ${{ secrets.TFC_ORGANIZATION }}
-        run: |
-          cat <<EOF > backend-config.hcl
-            organization = "$TFC_ORGANIZATION"
-            workspaces {
-              name = "google-private-active-active-${{ github.event.client_payload.github.payload.issue.number }}"
-            }
-          EOF
 
       - name: Terraform Init
         id: init
@@ -184,20 +143,15 @@ jobs:
 
       - name: Write Terraform Variables
         working-directory: ${{ env.WORK_DIR_PATH }}
-        env:
-          GOOGLE_SERVICE_ACCOUNT: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
-          TFE_HOSTNAME: ${{ secrets.TFE_HOSTNAME }}
-          TFE_ORGANIZATION: ${{ secrets.TFE_ORGANIZATION }}
-          TFE_TOKEN: ${{ secrets.TFE_TOKEN }}
-          TFE_WORKSPACE: ${{ secrets.TFE_WORKSPACE }}
         run: |
           cat <<EOF > github.auto.tfvars
-          existing_service_account_id = "$GOOGLE_SERVICE_ACCOUNT"
+          iact_subnet_list = ["( dig +short @resolver1.opendns.com myip.opendns.com )/32"]
+          existing_service_account_id = "${{ secrets.GOOGLE_SERVICE_ACCOUNT }}"
           tfe = {
-            hostname     = "$TFE_HOSTNAME"
-            organization = "$TFE_ORGANIZATION"
-            token        = "$TFE_TOKEN"
-            workspace    = "$TFE_WORKSPACE"
+            hostname     = "${{ secrets.TFE_HOSTNAME }}"
+            organization = "${{ secrets.TFE_ORGANIZATION }}"
+            token        = "${{ secrets.TFE_TOKEN }}"
+            workspace    = "${{ secrets.TFE_WORKSPACE }}"
           }
           EOF
 
@@ -230,14 +184,13 @@ jobs:
       contents: read
       pull-requests: write
     env:
-      WORK_DIR_PATH: ./tests/private-tcp-active-active
+      WORK_DIR_PATH: ./tests/private-active-active
     steps:
       - name: Create URL to the run output
         id: vars
         run: echo ::set-output name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
 
-      # Checkout the branch of the pull request being tested
-      - name: Checkout
+      - name: Checkout Pull Request Branch
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
         with:
           repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
@@ -256,32 +209,14 @@ jobs:
           sed --in-place "s/source = \"..\/..\/fixtures\/test_proxy\"/source = \"github.com\/$LOGIN\/$NAME\/\/fixtures\/test_proxy?ref=$SHA\"/" main.tf
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v2
         with:
           cli_config_credentials_hostname: 'app.terraform.io'
           cli_config_credentials_token: ${{ secrets.TFC_TOKEN }}
-          terraform_version: 1.0.11
-          terraform_wrapper: false
+          terraform_version: 1.1.7
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@62d4898025f6041e16b1068643bfc5a696863587 # v1.1.0
-        with:
-          project_id: ${{ secrets.GOOGLE_PROJECT }}
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-          export_default_credentials: true
-
-      - name: Configure Terraform Backend
-        id: backend-config
-        working-directory: ${{ env.WORK_DIR_PATH }}
-        env:
-          TFC_ORGANIZATION: ${{ secrets.TFC_ORGANIZATION }}
-        run: |
-          cat <<EOF > backend-config.hcl
-            organization = "$TFC_ORGANIZATION"
-            workspaces {
-              name = "google-private-tcp-active-active-${{ github.event.client_payload.github.payload.issue.number }}"
-            }
-          EOF
 
       - name: Terraform Init
         id: init
@@ -290,20 +225,15 @@ jobs:
 
       - name: Write Terraform Variables
         working-directory: ${{ env.WORK_DIR_PATH }}
-        env:
-          GOOGLE_SERVICE_ACCOUNT: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
-          TFE_HOSTNAME: ${{ secrets.TFE_HOSTNAME }}
-          TFE_ORGANIZATION: ${{ secrets.TFE_ORGANIZATION }}
-          TFE_TOKEN: ${{ secrets.TFE_TOKEN }}
-          TFE_WORKSPACE: ${{ secrets.TFE_WORKSPACE }}
         run: |
           cat <<EOF > github.auto.tfvars
-          existing_service_account_id = "$GOOGLE_SERVICE_ACCOUNT"
+          iact_subnet_list = ["( dig +short @resolver1.opendns.com myip.opendns.com )/32"]
+          existing_service_account_id = "${{ secrets.GOOGLE_SERVICE_ACCOUNT }}"
           tfe = {
-            hostname     = "$TFE_HOSTNAME"
-            organization = "$TFE_ORGANIZATION"
-            token        = "$TFE_TOKEN"
-            workspace    = "$TFE_WORKSPACE"
+            hostname     = "${{ secrets.TFE_HOSTNAME }}"
+            organization = "${{ secrets.TFE_ORGANIZATION }}"
+            token        = "${{ secrets.TFE_TOKEN }}"
+            workspace    = "${{ secrets.TFE_WORKSPACE }}"
           }
           EOF
 
@@ -321,220 +251,6 @@ jobs:
           comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
           body: |
             ${{ format('### {0} Terraform Private TCP Active/Active Destruction Report', job.status == 'success' && ':white_check_mark:' || ':x:') }}
-
-            ${{ format(':link: [Action Summary Page]({0})', steps.vars.outputs.run-url) }}
-
-            ${{ format('- {0} Terraform Init', steps.init.outcome == 'success' && ':white_check_mark:' || ':x:') }}
-
-            ${{ format('- {0} Terraform Destroy', steps.destroy.outcome == 'success' && ':white_check_mark:' || ':x:') }}
-
-  standalone_external_rhel8_worker:
-    name: Destroy resources from Standalone External Rhel8 Worker
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'standalone-external-rhel8-worker') }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-    env:
-      WORK_DIR_PATH: ./tests/standalone-external-rhel8-worker
-    steps:
-      - name: Create URL to the run output
-        id: vars
-        run: echo ::set-output name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
-
-      # Checkout the branch of the pull request being tested
-      - name: Checkout
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-        with:
-          repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.client_payload.pull_request.head.sha }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          persist-credentials: false
-
-      - name: Set Terraform Module Source
-        working-directory: ${{ env.WORK_DIR_PATH }}
-        env:
-          LOGIN: ${{ github.event.client_payload.pull_request.head.repo.owner.login }}
-          NAME: ${{ github.event.client_payload.pull_request.head.repo.name }}
-          SHA: ${{ github.event.client_payload.pull_request.head.sha }}
-        run: |
-          sed --in-place "s/source = \"..\/..\"/source = \"github.com\/$LOGIN\/$NAME?ref=$SHA\"/" main.tf
-          sed --in-place "s/source = \"..\/..\/fixtures\/test_proxy\"/source = \"github.com\/$LOGIN\/$NAME\/\/fixtures\/test_proxy?ref=$SHA\"/" main.tf
-
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
-        with:
-          cli_config_credentials_hostname: 'app.terraform.io'
-          cli_config_credentials_token: ${{ secrets.TFC_TOKEN }}
-          terraform_version: 1.0.11
-          terraform_wrapper: false
-
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@62d4898025f6041e16b1068643bfc5a696863587 # v1.1.0
-        with:
-          project_id: ${{ secrets.GOOGLE_PROJECT }}
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-          export_default_credentials: true
-
-      - name: Configure Terraform Backend
-        id: backend-config
-        working-directory: ${{ env.WORK_DIR_PATH }}
-        env:
-          TFC_ORGANIZATION: ${{ secrets.TFC_ORGANIZATION }}
-        run: |
-          cat <<EOF > backend-config.hcl
-            organization = "$TFC_ORGANIZATION"
-            workspaces {
-              name = "google-standalone-external-rhel8-worker-${{ github.event.client_payload.github.payload.issue.number }}"
-            }
-          EOF
-
-      - name: Terraform Init
-        id: init
-        working-directory: ${{ env.WORK_DIR_PATH }}
-        run: terraform init -backend-config=backend-config.hcl -input=false -no-color
-
-      - name: Write Terraform Variables
-        working-directory: ${{ env.WORK_DIR_PATH }}
-        env:
-          GOOGLE_SERVICE_ACCOUNT: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
-          TFE_HOSTNAME: ${{ secrets.TFE_HOSTNAME }}
-          TFE_ORGANIZATION: ${{ secrets.TFE_ORGANIZATION }}
-          TFE_TOKEN: ${{ secrets.TFE_TOKEN }}
-          TFE_WORKSPACE: ${{ secrets.TFE_WORKSPACE }}
-        run: |
-          cat <<EOF > github.auto.tfvars
-          existing_service_account_id = "$GOOGLE_SERVICE_ACCOUNT"
-          license_file = ""
-          tfe = {
-            hostname     = "$TFE_HOSTNAME"
-            organization = "$TFE_ORGANIZATION"
-            token        = "$TFE_TOKEN"
-            workspace    = "$TFE_WORKSPACE"
-          }
-          EOF
-
-      - name: Terraform Destroy
-        id: destroy
-        working-directory: ${{ env.WORK_DIR_PATH }}
-        run: terraform destroy -auto-approve -input=false -no-color
-
-      - name: Update comment
-        if: ${{ always() }}
-        uses: peter-evans/create-or-update-comment@3383acd359705b10cb1eeef05c0e88c056ea4666 # v3.0.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
-          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
-          body: |
-            ${{ format('### {0} Terraform Standalone External Rhel8 Worker Destruction Report', job.status == 'success' && ':white_check_mark:' || ':x:') }}
-
-            ${{ format(':link: [Action Summary Page]({0})', steps.vars.outputs.run-url) }}
-
-            ${{ format('- {0} Terraform Init', steps.init.outcome == 'success' && ':white_check_mark:' || ':x:') }}
-
-            ${{ format('- {0} Terraform Destroy', steps.destroy.outcome == 'success' && ':white_check_mark:' || ':x:') }}
-
-standalone_mounted_disk:
-    name: Destroy resources from Standalone Mounted Disk
-    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'standalone-mounted-disk') }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-    env:
-      WORK_DIR_PATH: ./tests/standalone-mounted-disk
-    steps:
-      - name: Create URL to the run output
-        id: vars
-        run: echo ::set-output name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
-
-      # Checkout the branch of the pull request being tested
-      - name: Checkout
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-        with:
-          repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.client_payload.pull_request.head.sha }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          persist-credentials: false
-
-      - name: Set Terraform Module Source
-        working-directory: ${{ env.WORK_DIR_PATH }}
-        env:
-          LOGIN: ${{ github.event.client_payload.pull_request.head.repo.owner.login }}
-          NAME: ${{ github.event.client_payload.pull_request.head.repo.name }}
-          SHA: ${{ github.event.client_payload.pull_request.head.sha }}
-        run: |
-          sed --in-place "s/source = \"..\/..\"/source = \"github.com\/$LOGIN\/$NAME?ref=$SHA\"/" main.tf
-          sed --in-place "s/source = \"..\/..\/fixtures\/test_proxy\"/source = \"github.com\/$LOGIN\/$NAME\/\/fixtures\/test_proxy?ref=$SHA\"/" main.tf
-
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
-        with:
-          cli_config_credentials_hostname: 'app.terraform.io'
-          cli_config_credentials_token: ${{ secrets.TFC_TOKEN }}
-          terraform_version: 1.0.11
-          terraform_wrapper: false
-
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@62d4898025f6041e16b1068643bfc5a696863587 # v1.1.0
-        with:
-          project_id: ${{ secrets.GOOGLE_PROJECT }}
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-          export_default_credentials: true
-
-      - name: Configure Terraform Backend
-        id: backend-config
-        working-directory: ${{ env.WORK_DIR_PATH }}
-        env:
-          TFC_ORGANIZATION: ${{ secrets.TFC_ORGANIZATION }}
-        run: |
-          cat <<EOF > backend-config.hcl
-            organization = "$TFC_ORGANIZATION"
-            workspaces {
-              name = "google-standalone-mounted-disk-${{ github.event.client_payload.github.payload.issue.number }}"
-            }
-          EOF
-
-      - name: Terraform Init
-        id: init
-        working-directory: ${{ env.WORK_DIR_PATH }}
-        run: terraform init -backend-config=backend-config.hcl -input=false -no-color
-
-      - name: Write Terraform Variables
-        working-directory: ${{ env.WORK_DIR_PATH }}
-        env:
-          GOOGLE_SERVICE_ACCOUNT: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
-          TFE_HOSTNAME: ${{ secrets.TFE_HOSTNAME }}
-          TFE_ORGANIZATION: ${{ secrets.TFE_ORGANIZATION }}
-          TFE_TOKEN: ${{ secrets.TFE_TOKEN }}
-          TFE_WORKSPACE: ${{ secrets.TFE_WORKSPACE }}
-        run: |
-          cat <<EOF > github.auto.tfvars
-          existing_service_account_id = "$GOOGLE_SERVICE_ACCOUNT"
-          license_file = ""
-          tfe = {
-            hostname     = "$TFE_HOSTNAME"
-            organization = "$TFE_ORGANIZATION"
-            token        = "$TFE_TOKEN"
-            workspace    = "$TFE_WORKSPACE"
-          }
-          EOF
-
-      - name: Terraform Destroy
-        id: destroy
-        working-directory: ${{ env.WORK_DIR_PATH }}
-        run: terraform destroy -auto-approve -input=false -no-color
-
-      - name: Update comment
-        if: ${{ always() }}
-        uses: peter-evans/create-or-update-comment@3383acd359705b10cb1eeef05c0e88c056ea4666 # v3.0.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
-          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
-          body: |
-            ${{ format('### {0} Terraform Standalone Mounted Disk Destruction Report', job.status == 'success' && ':white_check_mark:' || ':x:') }}
 
             ${{ format(':link: [Action Summary Page]({0})', steps.vars.outputs.run-url) }}
 

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -10,7 +10,7 @@ env:
   GOOGLE_PROJECT: ${{ secrets.GOOGLE_PROJECT }}
   GOOGLE_REGION: ${{ secrets.GOOGLE_REGION }}
   GOOGLE_ZONE: ${{ secrets.GOOGLE_ZONE }}
-  
+
 jobs:
   public_active_active:
     name: Run tf-test on Public Active/Active
@@ -76,7 +76,7 @@ jobs:
         id: init
         working-directory: ${{ env.WORK_DIR_PATH }}
         run: terraform init -input=false -no-color
-      
+
       - name: Write Terraform Variables
         working-directory: ${{ env.WORK_DIR_PATH }}
         run: |
@@ -110,11 +110,9 @@ jobs:
       - name: Wait For TFE
         id: wait-for-tfe
         timeout-minutes: 25
-        env:
-          HEALTH_CHECK_URL: ${{ steps.retrieve-health-check-url.outputs.stdout }}
         run: |
           echo "Curling \`health_check_url\` for a return status of 200..."
-          while ! curl -sfS --max-time 5 "$HEALTH_CHECK_URL"; do sleep 5; done
+          while ! curl -sfS --max-time 5 "${{ steps.retrieve-health-check-url.outputs.stdout }}"; do sleep 5; done
 
       - name: Retrieve TFE URL
         id: retrieve-tfe-url
@@ -153,7 +151,7 @@ jobs:
           response=$( \
             curl \
             --fail \
-            --retry 5 \
+            --retry 15 \
             --verbose \
             --header 'Content-Type: application/json' \
             --data @./payload.json \
@@ -162,10 +160,8 @@ jobs:
 
       - name: Retrieve Admin Token
         id: retrieve-admin-token
-        env:
-          RESPONSE: ${{ steps.create-admin.outputs.response }}
         run: |
-          token=$(echo "$RESPONSE" | jq --raw-output '.token')
+          token=$(echo "${{ steps.create-admin.outputs.response }}" | jq --raw-output '.token')
           echo "::set-output name=token::$token"
 
       - name: Run k6 Smoke Test
@@ -210,905 +206,461 @@ jobs:
 
             ${{ github.event.client_payload.slash_command.args.named.destroy != 'false' && format('- {0} Terraform Destroy', steps.destroy.outcome == 'success' && ':white_check_mark:' || ':x:') || '' }}
 
-  # private_active_active:
-  #   name: Run tf-test on Private Active/Active
-  #   if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'private-active-active')  || contains(fromJSON('["all", "private-active-active"]'), inputs.on_demand_scenario) }}
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     contents: read
-  #     pull-requests: write
-  #   env:
-  #     WORK_DIR_PATH: ./tests/private-active-active
-  #     K6_WORK_DIR_PATH: ./tests/tfe-load-test
-  #   steps:
-  #     - name: Create URL to the run output
-  #       id: vars
-  #       run: echo ::set-output name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
-
-  #     - name: Checkout Pull Request Branch
-  #       uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-  #       with:
-  #         repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
-  #         ref: ${{ github.event.client_payload.pull_request.head.sha }}
-  #         token: ${{ secrets.GITHUB_TOKEN }}
-  #         persist-credentials: false
-
-  #     - name: Set Terraform Module Source
-  #       working-directory: ${{ env.WORK_DIR_PATH }}
-  #       env:
-  #         LOGIN: ${{ github.event.client_payload.pull_request.head.repo.owner.login }}
-  #         NAME: ${{ github.event.client_payload.pull_request.head.repo.name }}
-  #         SHA: ${{ github.event.client_payload.pull_request.head.sha }}
-  #       run: |
-  #         sed --in-place "s/source = \"..\/..\"/source = \"github.com\/$LOGIN\/$NAME?ref=$SHA\"/" main.tf
-  #         sed --in-place "s/source = \"..\/..\/fixtures\/test_proxy\"/source = \"github.com\/$LOGIN\/$NAME\/\/fixtures\/test_proxy?ref=$SHA\"/" main.tf
-
-  #     - name: Checkout TFE Load Test
-  #       uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-  #       with:
-  #         path: ${{ env.K6_WORK_DIR_PATH }}
-  #         repository: hashicorp/tfe-load-test
-  #         token: ${{ secrets.GH_TFE_LOAD_TEST_TOKEN }}
-  #         persist-credentials: false
-
-  #     - name: Install required tools
-  #       working-directory: ${{ env.K6_WORK_DIR_PATH }}
-  #       env:
-  #         K6_URL: https://github.com/loadimpact/k6/releases/download/v0.31.1/k6-v0.31.1-linux64.tar.gz
-  #       run: |
-  #         sudo apt-get install jq
-  #         curl -L $K6_URL | tar -xz --strip-components=1
-
-  #     - name: Setup Terraform
-  #       uses: hashicorp/setup-terraform@v2
-  #       with:
-  #         cli_config_credentials_hostname: 'app.terraform.io'
-  #         cli_config_credentials_token: ${{ secrets.PRIVATE_ACTIVE_ACTIVE_TFC_TOKEN }}
-  #         terraform_version: 1.1.7
-  #         terraform_wrapper: true
-
-  #     - name: Set up Cloud SDK
-  #       uses: google-github-actions/setup-gcloud@v0 # bug present in v1 that prevents gcloud ssh
-  #       with:
-  #         project_id: ${{ secrets.GOOGLE_PROJECT }}
-  #         service_account_key: ${{ secrets.GCP_SA_KEY }}
-  #         export_default_credentials: true
-
-  #     - name: Terraform Init
-  #       id: init
-  #       working-directory: ${{ env.WORK_DIR_PATH }}
-  #       run: |
-  #         terraform init \
-  #           -backend-config="hostname=app.terraform.io" \
-  #           -backend-config="organization=${{ secrets.TFC_ORGANIZATION }}" \
-  #           -backend-config="workspace=google-private-active-active"
-      
-  #     - name: Write Terraform Variables
-  #       working-directory: ${{ env.WORK_DIR_PATH }}
-  #       run: |
-  #         cat <<EOF > github.auto.tfvars
-  #         existing_service_account_id = "${{ secrets.GOOGLE_SERVICE_ACCOUNT }}"
-  #         tfe = {
-  #           hostname     = "${{ secrets.TFE_HOSTNAME }}"
-  #           organization = "${{ secrets.TFE_ORGANIZATION }}"
-  #           token        = "${{ secrets.TFE_TOKEN }}"
-  #           workspace    = "${{ secrets.TFE_WORKSPACE }}"
-  #         }
-  #         EOF
-
-  #     - name: Terraform Validate
-  #       id: validate
-  #       working-directory: ${{ env.WORK_DIR_PATH }}
-  #       run: terraform validate -no-color
-
-  #     - name: Terraform Apply
-  #       id: apply
-  #       working-directory: ${{ env.WORK_DIR_PATH }}
-  #       run: terraform apply -auto-approve -input=false -no-color
-
-  #     - name: Retrieve Health Check URL
-  #       id: retrieve-health-check-url
-  #       working-directory: ${{ env.WORK_DIR_PATH }}
-  #       run: |
-  #         terraform output -no-color -raw health_check_url
-
-  #     - name: Retrieve Instance Name
-  #       id: retrieve-instance-name
-  #       working-directory: ${{ env.WORK_DIR_PATH }}
-  #       run: |
-  #         terraform output -no-color -raw proxy_instance_name
-
-  #     - name: Retrieve Instance Zone
-  #       id: retrieve-instance-zone
-  #       working-directory: ${{ env.WORK_DIR_PATH }}
-  #       run: |
-  #         terraform output -no-color -raw proxy_instance_zone
-
-
-  #     - name: Increasing the TCP Upload Bandwidth
-  #       id: increasing-the-tcp-upload-bandwidth-paa
-  #       working-directory: ${{ env.WORK_DIR_PATH }}
-  #       run: |
-  #         $(gcloud info --format="value(basic.python_location)") -m pip install numpy
-  #         export CLOUDSDK_PYTHON_SITEPACKAGES=1
-
-  #     - name: Start SOCKS5 Proxy
-  #       env:
-  #         INSTANCE_NAME: ${{ steps.retrieve-instance-name.outputs.stdout }}
-  #         INSTANCE_ZONE: ${{ steps.retrieve-instance-zone.outputs.stdout }}
-  #       run: |
-  #         gcloud compute ssh \
-  #         --quiet \
-  #         --ssh-key-expire-after="1440m" \
-  #         --tunnel-through-iap \
-  #         --zone="$INSTANCE_ZONE" \
-  #         "$INSTANCE_NAME" \
-  #         -- -f -N -p 22 -D localhost:5000
-
-  #     - name: Wait For TFE
-  #       id: wait-for-tfe
-  #       timeout-minutes: 25
-  #       env:
-  #         HEALTH_CHECK_URL: ${{ steps.retrieve-health-check-url.outputs.stdout }}
-  #       run: |
-  #         echo "Curling \`health_check_url\` for a return status of 200..."
-  #         while ! curl \
-  #           -sfS --max-time 5 --proxy socks5://localhost:5000 \
-  #           $HEALTH_CHECK_URL; \
-  #           do sleep 5; done
-
-  #     - name: Retrieve TFE URL
-  #       id: retrieve-tfe-url
-  #       working-directory: ${{ env.WORK_DIR_PATH }}
-  #       run: |
-  #         terraform output -no-color -raw tfe_url
-
-  #     - name: Retrieve IACT URL
-  #       id: retrieve-iact-url
-  #       working-directory: ${{ env.WORK_DIR_PATH }}
-  #       run: |
-  #         terraform output -no-color -raw iact_url
-
-  #     - name: Retrieve IACT
-  #       id: retrieve-iact
-  #       env:
-  #         IACT_URL: ${{ steps.retrieve-iact-url.outputs.stdout }}
-  #       run: |
-  #         token=$(curl --fail --retry 5 --verbose --proxy socks5://localhost:5000 "$IACT_URL")
-  #         echo "::set-output name=token::$token"
-
-  #     - name: Retrieve Initial Admin User URL
-  #       id: retrieve-initial-admin-user-url
-  #       working-directory: ${{ env.WORK_DIR_PATH }}
-  #       run: |
-  #         terraform output -no-color -raw initial_admin_user_url
-
-  #     - name: Create Admin in TFE
-  #       id: create-admin
-  #       env:
-  #         TFE_PASSWORD: ${{ secrets.TFE_PASSWORD }}
-  #         IAU_URL: ${{ steps.retrieve-initial-admin-user-url.outputs.stdout }}
-  #         IACT_TOKEN: ${{ steps.retrieve-iact.outputs.token }}
-  #       run: |
-  #         echo \
-  #           '{"username": "test", "email": "tf-onprem-team@hashicorp.com", "password": "$TFE_PASSWORD"}' \
-  #           > ./payload.json
-  #         response=$( \
-  #           curl \
-  #           --fail \
-  #           --retry 5 \
-  #           --verbose \
-  #           --header 'Content-Type: application/json' \
-  #           --data @./payload.json \
-  #           --proxy socks5://localhost:5000 \
-  #           "$IAU_URL"?token="$IACT_TOKEN")
-  #         echo "::set-output name=response::$response"
-
-  #     - name: Retrieve Admin Token
-  #       id: retrieve-admin-token
-  #       env:
-  #         RESPONSE: ${{ steps.create-admin.outputs.response }}
-  #       run: |
-  #         token=$(echo "$RESPONSE" | jq --raw-output '.token')
-  #         echo "::set-output name=token::$token"
-
-  #     - name: Run k6 Smoke Test
-  #       id: run-smoke-test
-  #       working-directory: ${{ env.K6_WORK_DIR_PATH }}
-  #       env:
-  #         K6_PATHNAME: "./k6"
-  #         TFE_URL: "${{ steps.retrieve-tfe-url.outputs.stdout }}"
-  #         TFE_API_TOKEN: "${{ steps.retrieve-admin-token.outputs.token }}"
-  #         TFE_EMAIL: tf-onprem-team@hashicorp.com
-  #         http_proxy: socks5://localhost:5000/
-  #         https_proxy: socks5://localhost:5000/
-  #       run: |
-  #         make smoke-test
-
-  #     - name: Terraform Destroy
-  #       id: destroy
-  #       if: ${{ always() && github.event.client_payload.slash_command.args.named.destroy != 'false' }}
-  #       working-directory: ${{ env.WORK_DIR_PATH }}
-  #       run: terraform destroy -auto-approve -input=false -no-color
-
-  #     - name: Update comment
-  #       if: ${{ always() }}
-  #       uses: peter-evans/create-or-update-comment@3383acd359705b10cb1eeef05c0e88c056ea4666 # v3.0.0
-  #       with:
-  #         token: ${{ secrets.GITHUB_TOKEN }}
-  #         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
-  #         comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
-  #         body: |
-  #           ${{ format('### {0} Terraform Private Active/Active Test Report', job.status == 'success' && ':white_check_mark:' || ':x:') }}
-
-  #           ${{ format(':link: [Action Summary Page]({0})', steps.vars.outputs.run-url) }}
-
-  #           ${{ format('- {0} Terraform Init', steps.init.outcome == 'success' && ':white_check_mark:' || ':x:') }}
-
-  #           ${{ format('- {0} Terraform Validate', steps.validate.outcome == 'success' && ':white_check_mark:' || ':x:') }}
-
-  #           ${{ format('- {0} Terraform Apply', steps.apply.outcome == 'success' && ':white_check_mark:' || ':x:') }}
-
-  #           ${{ format('- {0} Run k6 Smoke Test', steps.run-smoke-test.outcome == 'success' && ':white_check_mark:' || ':x:') }}
-
-  #           ${{ github.event.client_payload.slash_command.args.named.destroy != 'false' && format('- {0} Terraform Destroy', steps.destroy.outcome == 'success' && ':white_check_mark:' || ':x:') || '' }}
-
-  # private_tcp_active_active:
-  #   name: Run tf-test on Private TCP Active/Active
-  #   if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'private-tcp-active-active')  || contains(fromJSON('["all", "private-tcp-active-active"]'), inputs.on_demand_scenario) }}
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     contents: read
-  #     pull-requests: write
-  #   env:
-  #     WORK_DIR_PATH: ./tests/private-tcp-active-active
-  #     K6_WORK_DIR_PATH: ./tests/tfe-load-test
-  #   steps:
-  #     - name: Create URL to the run output
-  #       id: vars
-  #       run: echo ::set-output name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
-
-  #     - name: Checkout Pull Request Branch
-  #       uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-  #       with:
-  #         repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
-  #         ref: ${{ github.event.client_payload.pull_request.head.sha }}
-  #         token: ${{ secrets.GITHUB_TOKEN }}
-  #         persist-credentials: false
-
-  #     - name: Set Terraform Module Source
-  #       working-directory: ${{ env.WORK_DIR_PATH }}
-  #       env:
-  #         LOGIN: ${{ github.event.client_payload.pull_request.head.repo.owner.login }}
-  #         NAME: ${{ github.event.client_payload.pull_request.head.repo.name }}
-  #         SHA: ${{ github.event.client_payload.pull_request.head.sha }}
-  #       run: |
-  #         sed --in-place "s/source = \"..\/..\"/source = \"github.com\/$LOGIN\/$NAME?ref=$SHA\"/" main.tf
-  #         sed --in-place "s/source = \"..\/..\/fixtures\/test_proxy\"/source = \"github.com\/$LOGIN\/$NAME\/\/fixtures\/test_proxy?ref=$SHA\"/" main.tf
-
-  #     - name: Checkout TFE Load Test
-  #       uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-  #       with:
-  #         path: ${{ env.K6_WORK_DIR_PATH }}
-  #         repository: hashicorp/tfe-load-test
-  #         token: ${{ secrets.GH_TFE_LOAD_TEST_TOKEN }}
-  #         persist-credentials: false
-
-  #     - name: Install required tools
-  #       working-directory: ${{ env.K6_WORK_DIR_PATH }}
-  #       env:
-  #         K6_URL: https://github.com/loadimpact/k6/releases/download/v0.31.1/k6-v0.31.1-linux64.tar.gz
-  #       run: |
-  #         sudo apt-get install jq
-  #         curl -L $K6_URL | tar -xz --strip-components=1
-
-  #     - name: Setup Terraform
-  #       uses: hashicorp/setup-terraform@v2
-  #       with:
-  #         cli_config_credentials_hostname: 'app.terraform.io'
-  #         cli_config_credentials_token: ${{ secrets.PRIVATE_TCP_ACTIVE_ACTIVE_TFC_TOKEN }}
-  #         terraform_version: 1.1.7
-  #         terraform_wrapper: true
-
-  #     - name: Set up Cloud SDK
-  #       uses: google-github-actions/setup-gcloud@v0 # bug present in v1 that prevents gcloud ssh
-  #       with:
-  #         project_id: ${{ secrets.GOOGLE_PROJECT }}
-  #         service_account_key: ${{ secrets.GCP_SA_KEY }}
-  #         export_default_credentials: true
-
-  #     - name: Terraform Init
-  #       id: init
-  #       working-directory: ${{ env.WORK_DIR_PATH }}
-  #       run: |
-  #         terraform init \
-  #           -backend-config="hostname=app.terraform.io" \
-  #           -backend-config="organization=${{ secrets.TFC_ORGANIZATION }}" \
-  #           -backend-config="workspace=google-private-tcp-active-active"
-
-  #     - name: Write Terraform Variables
-  #       working-directory: ${{ env.WORK_DIR_PATH }}
-  #       run: |
-  #         cat <<EOF > github.auto.tfvars
-  #         existing_service_account_id = "${{ secrets.GOOGLE_SERVICE_ACCOUNT }}"
-  #         tfe = {
-  #           hostname     = "${{ secrets.TFE_HOSTNAME }}"
-  #           organization = "${{ secrets.TFE_ORGANIZATION }}"
-  #           token        = "${{ secrets.TFE_TOKEN }}"
-  #           workspace    = "${{ secrets.TFE_WORKSPACE }}"
-  #         }
-  #         EOF
-
-  #     - name: Terraform Validate
-  #       id: validate
-  #       working-directory: ${{ env.WORK_DIR_PATH }}
-  #       run: terraform validate -no-color
-
-  #     - name: Terraform Apply
-  #       id: apply
-  #       working-directory: ${{ env.WORK_DIR_PATH }}
-  #       run: terraform apply -auto-approve -input=false -no-color
-
-  #     - name: Retrieve Health Check URL
-  #       id: retrieve-health-check-url
-  #       working-directory: ${{ env.WORK_DIR_PATH }}
-  #       run: |
-  #         terraform output -no-color -raw health_check_url
-
-  #     - name: Retrieve Instance Name
-  #       id: retrieve-instance-name
-  #       working-directory: ${{ env.WORK_DIR_PATH }}
-  #       run: |
-  #         terraform output -no-color -raw proxy_instance_name
-
-  #     - name: Retrieve Instance Zone
-  #       id: retrieve-instance-zone
-  #       working-directory: ${{ env.WORK_DIR_PATH }}
-  #       run: |
-  #         terraform output -no-color -raw proxy_instance_zone
-
-
-  #     - name: Increasing the TCP Upload Bandwidth
-  #       id: increasing-the-tcp-upload-bandwidth-ptaa
-  #       working-directory: ${{ env.WORK_DIR_PATH }}
-  #       run: |
-  #         $(gcloud info --format="value(basic.python_location)") -m pip install numpy
-  #         export CLOUDSDK_PYTHON_SITEPACKAGES=1
-
-  #     - name: Start SOCKS5 Proxy
-  #       env:
-  #         INSTANCE_NAME: ${{ steps.retrieve-instance-name.outputs.stdout }}
-  #         INSTANCE_ZONE: ${{ steps.retrieve-instance-zone.outputs.stdout }}
-  #       run: |
-  #         gcloud compute ssh \
-  #         --quiet \
-  #         --ssh-key-expire-after="1440m" \
-  #         --tunnel-through-iap \
-  #         --zone="$INSTANCE_ZONE" \
-  #         "$INSTANCE_NAME" \
-  #         -- \
-  #         -o 'ServerAliveInterval 5' \
-  #         -o 'ServerAliveCountMax 3' \
-  #         -f -N -p 22 -D localhost:5000
-
-  #     - name: Wait For TFE
-  #       id: wait-for-tfe
-  #       timeout-minutes: 25
-  #       env:
-  #         HEALTH_CHECK_URL: ${{ steps.retrieve-health-check-url.outputs.stdout }}
-  #       run: |
-  #         echo "Curling \`health_check_url\` for a return status of 200..."
-  #         while ! curl \
-  #           -sfS --max-time 5 --proxy socks5://localhost:5000 \
-  #           $HEALTH_CHECK_URL; \
-  #           do sleep 5; done
-
-  #     - name: Retrieve TFE URL
-  #       id: retrieve-tfe-url
-  #       working-directory: ${{ env.WORK_DIR_PATH }}
-  #       run: |
-  #         terraform output -no-color -raw tfe_url
-
-  #     - name: Retrieve IACT URL
-  #       id: retrieve-iact-url
-  #       working-directory: ${{ env.WORK_DIR_PATH }}
-  #       run: |
-  #         terraform output -no-color -raw iact_url
-
-  #     - name: Retrieve IACT
-  #       id: retrieve-iact
-  #       env:
-  #         IACT_URL: ${{ steps.retrieve-iact-url.outputs.stdout }}
-  #       run: |
-  #         token=$(curl --fail --retry 5 --verbose --proxy socks5://localhost:5000 "$IACT_URL")
-  #         echo "::set-output name=token::$token"
-
-  #     - name: Retrieve Initial Admin User URL
-  #       id: retrieve-initial-admin-user-url
-  #       working-directory: ${{ env.WORK_DIR_PATH }}
-  #       run: |
-  #         terraform output -no-color -raw initial_admin_user_url
-
-  #     - name: Create Admin in TFE
-  #       id: create-admin
-  #       env:
-  #         TFE_PASSWORD: ${{ secrets.TFE_PASSWORD }}
-  #         IAU_URL: ${{ steps.retrieve-initial-admin-user-url.outputs.stdout }}
-  #         IACT_TOKEN: ${{ steps.retrieve-iact.outputs.token }}
-  #       run: |
-  #         echo \
-  #           '{"username": "test", "email": "tf-onprem-team@hashicorp.com", "password": "$TFE_PASSWORD"}' \
-  #           > ./payload.json
-  #         response=$( \
-  #           curl \
-  #           --fail \
-  #           --retry 5 \
-  #           --verbose \
-  #           --header 'Content-Type: application/json' \
-  #           --data @./payload.json \
-  #           --proxy socks5://localhost:5000 \
-  #           "$IAU_URL"?token="$IACT_TOKEN")
-  #         echo "::set-output name=response::$response"
-
-  #     - name: Retrieve Admin Token
-  #       id: retrieve-admin-token
-  #       env:
-  #         RESPONSE: ${{ steps.create-admin.outputs.response }}
-  #       run: |
-  #         token=$(echo "$RESPONSE" | jq --raw-output '.token')
-  #         echo "::set-output name=token::$token"
-
-  #     - name: Run k6 Smoke Test
-  #       id: run-smoke-test
-  #       working-directory: ${{ env.K6_WORK_DIR_PATH }}
-  #       env:
-  #         K6_PATHNAME: "./k6"
-  #         TFE_URL: "${{ steps.retrieve-tfe-url.outputs.stdout }}"
-  #         TFE_API_TOKEN: "${{ steps.retrieve-admin-token.outputs.token }}"
-  #         TFE_EMAIL: tf-onprem-team@hashicorp.com
-  #         http_proxy: socks5://localhost:5000/
-  #         https_proxy: socks5://localhost:5000/
-  #       run: |
-  #         make smoke-test
-
-  #     - name: Terraform Destroy
-  #       id: destroy
-  #       if: ${{ always() && github.event.client_payload.slash_command.args.named.destroy != 'false' }}
-  #       working-directory: ${{ env.WORK_DIR_PATH }}
-  #       run: terraform destroy -auto-approve -input=false -no-color
-
-  #     - name: Update comment
-  #       if: ${{ always() }}
-  #       uses: peter-evans/create-or-update-comment@3383acd359705b10cb1eeef05c0e88c056ea4666 # v3.0.0
-  #       with:
-  #         token: ${{ secrets.GITHUB_TOKEN }}
-  #         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
-  #         comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
-  #         body: |
-  #           ${{ format('### {0} Terraform Private TCP Active/Active Test Report', job.status == 'success' && ':white_check_mark:' || ':x:') }}
-
-  #           ${{ format(':link: [Action Summary Page]({0})', steps.vars.outputs.run-url) }}
-
-  #           ${{ format('- {0} Terraform Init', steps.init.outcome == 'success' && ':white_check_mark:' || ':x:') }}
-
-  #           ${{ format('- {0} Terraform Validate', steps.validate.outcome == 'success' && ':white_check_mark:' || ':x:') }}
-
-  #           ${{ format('- {0} Terraform Apply', steps.apply.outcome == 'success' && ':white_check_mark:' || ':x:') }}
-
-  #           ${{ format('- {0} Run k6 Smoke Test', steps.run-smoke-test.outcome == 'success' && ':white_check_mark:' || ':x:') }}
-
-  #           ${{ github.event.client_payload.slash_command.args.named.destroy != 'false' && format('- {0} Terraform Destroy', steps.destroy.outcome == 'success' && ':white_check_mark:' || ':x:') || '' }}
-
-  # standalone_external_rhel8_worker:
-  #   name: Run tf-test on Standalone External Rhel8 Worker
-  #   if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'standalone-external-rhel8-worker') }}
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     contents: read
-  #     pull-requests: write
-  #   env:
-  #     WORK_DIR_PATH: ./tests/standalone-external-rhel8-worker
-  #     K6_WORK_DIR_PATH: ./tests/tfe-load-test
-  #   steps:
-  #     - name: Create URL to the run output
-  #       id: vars
-  #       run: echo ::set-output name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
-
-  #     - name: Checkout Pull Request Branch
-  #       uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-  #       with:
-  #         repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
-  #         ref: ${{ github.event.client_payload.pull_request.head.sha }}
-  #         token: ${{ secrets.GITHUB_TOKEN }}
-  #         persist-credentials: false
-
-  #     - name: Set Terraform Module Source
-  #       working-directory: ${{ env.WORK_DIR_PATH }}
-  #       env:
-  #         LOGIN: ${{ github.event.client_payload.pull_request.head.repo.owner.login }}
-  #         NAME: ${{ github.event.client_payload.pull_request.head.repo.name }}
-  #         SHA: ${{ github.event.client_payload.pull_request.head.sha }}
-  #       run: |
-  #         sed --in-place "s/source = \"..\/..\"/source = \"github.com\/$LOGIN\/$NAME?ref=$SHA\"/" main.tf
-  #         sed --in-place "s/source = \"..\/..\/fixtures\/test_proxy\"/source = \"github.com\/$LOGIN\/$NAME\/\/fixtures\/test_proxy?ref=$SHA\"/" main.tf
-
-  #     - name: Checkout TFE Load Test
-  #       uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-  #       with:
-  #         path: ${{ env.K6_WORK_DIR_PATH }}
-  #         repository: hashicorp/tfe-load-test
-  #         token: ${{ secrets.GH_TFE_LOAD_TEST_TOKEN }}
-  #         persist-credentials: false
-
-  #     - name: Install required tools
-  #       working-directory: ${{ env.K6_WORK_DIR_PATH }}
-  #       env:
-  #         K6_URL: https://github.com/loadimpact/k6/releases/download/v0.31.1/k6-v0.31.1-linux64.tar.gz
-  #       run: |
-  #         sudo apt-get install jq
-  #         curl -L $K6_URL | tar -xz --strip-components=1
-
-  #     - name: Setup Terraform
-  #       uses: hashicorp/setup-terraform@v2
-  #       with:
-  #         cli_config_credentials_hostname: 'app.terraform.io'
-  #         cli_config_credentials_token: ${{ secrets.TFC_TOKEN }}
-  #         terraform_version: 1.1.7
-  #         terraform_wrapper: true
-
-  #     - name: Set up Cloud SDK
-  #       uses: google-github-actions/setup-gcloud@62d4898025f6041e16b1068643bfc5a696863587 # v1.1.0
-  #       with:
-  #         project_id: ${{ secrets.GOOGLE_PROJECT }}
-  #         service_account_key: ${{ secrets.GCP_SA_KEY }}
-  #         export_default_credentials: true
-
-  #     - name: Terraform Init
-  #       id: init
-  #       working-directory: ${{ env.WORK_DIR_PATH }}
-  #       run: |
-  #         terraform init \
-  #           -backend-config="hostname=app.terraform.io" \
-  #           -backend-config="organization=${{ secrets.TFC_ORGANIZATION }}" \
-  #           -backend-config="workspace=google-standalone-external-rhel8-worker"
-      
-  #     - name: Write Terraform Variables
-  #       working-directory: ${{ env.WORK_DIR_PATH }}
-  #       run: |
-  #         cat <<EOF > github.auto.tfvars
-  #         iact_subnet_list = ["( dig +short @resolver1.opendns.com myip.opendns.com )/32"]
-  #         license_file = ""
-  #         existing_service_account_id = "${{ secrets.GOOGLE_SERVICE_ACCOUNT }}"
-  #         tfe = {
-  #           hostname     = "${{ secrets.TFE_HOSTNAME }}"
-  #           organization = "${{ secrets.TFE_ORGANIZATION }}"
-  #           token        = "${{ secrets.TFE_TOKEN }}"
-  #           workspace    = "${{ secrets.TFE_WORKSPACE }}"
-  #         }
-  #         EOF
-
-  #     - name: Terraform Validate
-  #       id: validate
-  #       working-directory: ${{ env.WORK_DIR_PATH }}
-  #       run: terraform validate -no-color
-
-  #     - name: Terraform Apply
-  #       id: apply
-  #       working-directory: ${{ env.WORK_DIR_PATH }}
-  #       run: terraform apply -auto-approve -input=false -no-color
-
-  #     - name: Retrieve Health Check URL
-  #       id: retrieve-health-check-url
-  #       working-directory: ${{ env.WORK_DIR_PATH }}
-  #       run: |
-  #         terraform output -no-color -raw health_check_url
-
-  #     - name: Wait For TFE
-  #       id: wait-for-tfe
-  #       timeout-minutes: 25
-  #       env:
-  #         HEALTH_CHECK_URL: ${{ steps.retrieve-health-check-url.outputs.stdout }}
-  #       run: |
-  #         echo "Curling \`health_check_url\` for a return status of 200..."
-  #         while ! curl -sfS --max-time 5 "$HEALTH_CHECK_URL"; do sleep 5; done
-
-  #     - name: Retrieve TFE URL
-  #       id: retrieve-tfe-url
-  #       working-directory: ${{ env.WORK_DIR_PATH }}
-  #       run: |
-  #         terraform output -no-color -raw tfe_url
-
-  #     - name: Retrieve IACT URL
-  #       id: retrieve-iact-url
-  #       working-directory: ${{ env.WORK_DIR_PATH }}
-  #       run: |
-  #         terraform output -no-color -raw iact_url
-
-  #     - name: Retrieve IACT
-  #       id: retrieve-iact
-  #       run: |
-  #         token=$(curl --fail --retry 5 --verbose "${{ steps.retrieve-iact-url.outputs.stdout }}")
-  #         echo "::set-output name=token::$token"
-
-  #     - name: Retrieve Initial Admin User URL
-  #       id: retrieve-initial-admin-user-url
-  #       working-directory: ${{ env.WORK_DIR_PATH }}
-  #       run: |
-  #         terraform output -no-color -raw initial_admin_user_url
-
-  #     - name: Create Admin in TFE
-  #       id: create-admin
-  #       env:
-  #         TFE_PASSWORD: ${{ secrets.TFE_PASSWORD }}
-  #         IAU_URL: ${{ steps.retrieve-initial-admin-user-url.outputs.stdout }}
-  #         IACT: ${{ steps.retrieve-iact.outputs.token }}
-  #       run: |
-  #         echo \
-  #           '{"username": "test", "email": "tf-onprem-team@hashicorp.com", "password": "$TFE_PASSWORD"}' \
-  #           > ./payload.json
-  #         response=$( \
-  #           curl \
-  #           --fail \
-  #           --retry 5 \
-  #           --verbose \
-  #           --header 'Content-Type: application/json' \
-  #           --data @./payload.json \
-  #           "$IAU_URL"?token="$IACT")
-  #         echo "::set-output name=response::$response"
-
-  #     - name: Retrieve Admin Token
-  #       id: retrieve-admin-token
-  #       env:
-  #         RESPONSE: ${{ steps.create-admin.outputs.response }}
-  #       run: |
-  #         token=$(echo "$RESPONSE" | jq --raw-output '.token')
-  #         echo "::set-output name=token::$token"
-
-  #     - name: Run k6 Smoke Test
-  #       id: run-smoke-test
-  #       working-directory: ${{ env.K6_WORK_DIR_PATH }}
-  #       env:
-  #         K6_PATHNAME: "./k6"
-  #         TFE_URL: "${{ steps.retrieve-tfe-url.outputs.stdout }}"
-  #         TFE_API_TOKEN: "${{ steps.retrieve-admin-token.outputs.token }}"
-  #         TFE_EMAIL: tf-onprem-team@hashicorp.com
-  #       run: |
-  #         make smoke-test
-
-  #     - name: Terraform Destroy
-  #       id: destroy
-  #       if: ${{ always() && github.event.client_payload.slash_command.args.named.destroy != 'false' }}
-  #       working-directory: ${{ env.WORK_DIR_PATH }}
-  #       env:
-  #         TFE_HOSTNAME: ${{ secrets.TFE_HOSTNAME }}
-  #         TFE_TOKEN: ${{ secrets.TFE_TOKEN }}
-  #       run: terraform destroy -auto-approve -input=false -no-color
-
-  #     - name: Update comment
-  #       if: ${{ always() }}
-  #       uses: peter-evans/create-or-update-comment@3383acd359705b10cb1eeef05c0e88c056ea4666 # v3.0.0
-  #       with:
-  #         token: ${{ secrets.GITHUB_TOKEN }}
-  #         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
-  #         comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
-  #         body: |
-  #           ${{ format('### {0} Terraform Standalone External Rhel8 Worker Test Report', job.status == 'success' && ':white_check_mark:' || ':x:') }}
-
-  #           ${{ format(':link: [Action Summary Page]({0})', steps.vars.outputs.run-url) }}
-
-  #           ${{ format('- {0} Terraform Init', steps.init.outcome == 'success' && ':white_check_mark:' || ':x:') }}
-
-  #           ${{ format('- {0} Terraform Validate', steps.validate.outcome == 'success' && ':white_check_mark:' || ':x:') }}
-
-  #           ${{ format('- {0} Terraform Apply', steps.apply.outcome == 'success' && ':white_check_mark:' || ':x:') }}
-
-  #           ${{ format('- {0} Run k6 Smoke Test', steps.run-smoke-test.outcome == 'success' && ':white_check_mark:' || ':x:') }}
-
-  #           ${{ github.event.client_payload.slash_command.args.named.destroy != 'false' && format('- {0} Terraform Destroy', steps.destroy.outcome == 'success' && ':white_check_mark:' || ':x:') || '' }}
-
-  # standalone_mounted_disk:
-  #   name: Run tf-test on Standalone Mounted Disk
-  #   if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'standalone-mounted-disk') }}
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     contents: read
-  #     pull-requests: write
-  #   env:
-  #     WORK_DIR_PATH: ./tests/standalone-mounted-disk
-  #     K6_WORK_DIR_PATH: ./tests/tfe-load-test
-  #   steps:
-  #     - name: Create URL to the run output
-  #       id: vars
-  #       run: echo ::set-output name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
-
-  #     - name: Checkout Pull Request Branch
-  #       uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-  #       with:
-  #         repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
-  #         ref: ${{ github.event.client_payload.pull_request.head.sha }}
-  #         token: ${{ secrets.GITHUB_TOKEN }}
-  #         persist-credentials: false
-
-  #     - name: Set Terraform Module Source
-  #       working-directory: ${{ env.WORK_DIR_PATH }}
-  #       env:
-  #         LOGIN: ${{ github.event.client_payload.pull_request.head.repo.owner.login }}
-  #         NAME: ${{ github.event.client_payload.pull_request.head.repo.name }}
-  #         SHA: ${{ github.event.client_payload.pull_request.head.sha }}
-  #       run: |
-  #         sed --in-place "s/source = \"..\/..\"/source = \"github.com\/$LOGIN\/$NAME?ref=$SHA\"/" main.tf
-  #         sed --in-place "s/source = \"..\/..\/fixtures\/test_proxy\"/source = \"github.com\/$LOGIN\/$NAME\/\/fixtures\/test_proxy?ref=$SHA\"/" main.tf
-
-  #     - name: Checkout TFE Load Test
-  #       uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-  #       with:
-  #         path: ${{ env.K6_WORK_DIR_PATH }}
-  #         repository: hashicorp/tfe-load-test
-  #         token: ${{ secrets.GH_TFE_LOAD_TEST_TOKEN }}
-  #         persist-credentials: false
-
-  #     - name: Install required tools
-  #       working-directory: ${{ env.K6_WORK_DIR_PATH }}
-  #       env:
-  #         K6_URL: https://github.com/loadimpact/k6/releases/download/v0.31.1/k6-v0.31.1-linux64.tar.gz
-  #       run: |
-  #         sudo apt-get install jq
-  #         curl -L $K6_URL | tar -xz --strip-components=1
-
-  #     - name: Setup Terraform
-  #       uses: hashicorp/setup-terraform@v2
-  #       with:
-  #         cli_config_credentials_hostname: 'app.terraform.io'
-  #         cli_config_credentials_token: ${{ secrets.TFC_TOKEN }}
-  #         terraform_version: 1.1.7
-  #         terraform_wrapper: true
-
-  #     - name: Set up Cloud SDK
-  #       uses: google-github-actions/setup-gcloud@62d4898025f6041e16b1068643bfc5a696863587 # v1.1.0
-  #       with:
-  #         project_id: ${{ secrets.GOOGLE_PROJECT }}
-  #         service_account_key: ${{ secrets.GCP_SA_KEY }}
-  #         export_default_credentials: true
-
-  #     - name: Terraform Init
-  #       id: init
-  #       working-directory: ${{ env.WORK_DIR_PATH }}
-  #       run: |
-  #         terraform init \
-  #           -backend-config="hostname=app.terraform.io" \
-  #           -backend-config="organization=${{ secrets.TFC_ORGANIZATION }}" \
-  #           -backend-config="workspace=google-standalone-mounted-disk"
-      
-  #     - name: Write Terraform Variables
-  #       working-directory: ${{ env.WORK_DIR_PATH }}
-  #       run: |
-  #         cat <<EOF > github.auto.tfvars
-  #         iact_subnet_list = ["( dig +short @resolver1.opendns.com myip.opendns.com )/32"]
-  #         license_file = ""
-  #         existing_service_account_id = "${{ secrets.GOOGLE_SERVICE_ACCOUNT }}"
-  #         tfe = {
-  #           hostname     = "${{ secrets.TFE_HOSTNAME }}"
-  #           organization = "${{ secrets.TFE_ORGANIZATION }}"
-  #           token        = "${{ secrets.TFE_TOKEN }}"
-  #           workspace    = "${{ secrets.TFE_WORKSPACE }}"
-  #         }
-  #         EOF
-
-  #     - name: Terraform Validate
-  #       id: validate
-  #       working-directory: ${{ env.WORK_DIR_PATH }}
-  #       run: terraform validate -no-color
-
-  #     - name: Terraform Apply
-  #       id: apply
-  #       working-directory: ${{ env.WORK_DIR_PATH }}
-  #       run: terraform apply -auto-approve -input=false -no-color
-
-  #     - name: Retrieve Health Check URL
-  #       id: retrieve-health-check-url
-  #       working-directory: ${{ env.WORK_DIR_PATH }}
-  #       run: |
-  #         terraform output -no-color -raw health_check_url
-
-  #     - name: Wait For TFE
-  #       id: wait-for-tfe
-  #       timeout-minutes: 25
-  #       env:
-  #         HEALTH_CHECK_URL: ${{ steps.retrieve-health-check-url.outputs.stdout }}
-  #       run: |
-  #         echo "Curling \`health_check_url\` for a return status of 200..."
-  #         while ! curl -sfS --max-time 5 "$HEALTH_CHECK_URL"; do sleep 5; done
-
-  #     - name: Retrieve TFE URL
-  #       id: retrieve-tfe-url
-  #       working-directory: ${{ env.WORK_DIR_PATH }}
-  #       run: |
-  #         terraform output -no-color -raw tfe_url
-
-  #     - name: Retrieve IACT URL
-  #       id: retrieve-iact-url
-  #       working-directory: ${{ env.WORK_DIR_PATH }}
-  #       run: |
-  #         terraform output -no-color -raw iact_url
-
-  #     - name: Retrieve IACT
-  #       id: retrieve-iact
-  #       run: |
-  #         token=$(curl --fail --retry 5 --verbose "${{ steps.retrieve-iact-url.outputs.stdout }}")
-  #         echo "::set-output name=token::$token"
-
-  #     - name: Retrieve Initial Admin User URL
-  #       id: retrieve-initial-admin-user-url
-  #       working-directory: ${{ env.WORK_DIR_PATH }}
-  #       run: |
-  #         terraform output -no-color -raw initial_admin_user_url
-
-  #     - name: Create Admin in TFE
-  #       id: create-admin
-  #       env:
-  #         TFE_PASSWORD: ${{ secrets.TFE_PASSWORD }}
-  #         IAU_URL: ${{ steps.retrieve-initial-admin-user-url.outputs.stdout }}
-  #         IACT: ${{ steps.retrieve-iact.outputs.token }}
-  #       run: |
-  #         echo \
-  #           '{"username": "test", "email": "tf-onprem-team@hashicorp.com", "password": "$TFE_PASSWORD"}' \
-  #           > ./payload.json
-  #         response=$( \
-  #           curl \
-  #           --fail \
-  #           --retry 5 \
-  #           --verbose \
-  #           --header 'Content-Type: application/json' \
-  #           --data @./payload.json \
-  #           "$IAU_URL"?token="$IACT")
-  #         echo "::set-output name=response::$response"
-
-  #     - name: Retrieve Admin Token
-  #       id: retrieve-admin-token
-  #       env:
-  #         RESPONSE: ${{ steps.create-admin.outputs.response }}
-  #       run: |
-  #         token=$(echo "$RESPONSE" | jq --raw-output '.token')
-  #         echo "::set-output name=token::$token"
-
-  #     - name: Run k6 Smoke Test
-  #       id: run-smoke-test
-  #       working-directory: ${{ env.K6_WORK_DIR_PATH }}
-  #       env:
-  #         K6_PATHNAME: "./k6"
-  #         TFE_URL: "${{ steps.retrieve-tfe-url.outputs.stdout }}"
-  #         TFE_API_TOKEN: "${{ steps.retrieve-admin-token.outputs.token }}"
-  #         TFE_EMAIL: tf-onprem-team@hashicorp.com
-  #       run: |
-  #         make smoke-test
-
-  #     - name: Terraform Destroy
-  #       id: destroy
-  #       if: ${{ always() && github.event.client_payload.slash_command.args.named.destroy != 'false' }}
-  #       working-directory: ${{ env.WORK_DIR_PATH }}
-  #       env:
-  #         TFE_HOSTNAME: ${{ secrets.TFE_HOSTNAME }}
-  #         TFE_TOKEN: ${{ secrets.TFE_TOKEN }}
-  #       run: terraform destroy -auto-approve -input=false -no-color
-
-  #     - name: Update comment
-  #       if: ${{ always() }}
-  #       uses: peter-evans/create-or-update-comment@3383acd359705b10cb1eeef05c0e88c056ea4666 # v3.0.0
-  #       with:
-  #         token: ${{ secrets.GITHUB_TOKEN }}
-  #         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
-  #         comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
-  #         body: |
-  #           ${{ format('### {0} Terraform Standalone Mounted Disk Test Report', job.status == 'success' && ':white_check_mark:' || ':x:') }}
-
-  #           ${{ format(':link: [Action Summary Page]({0})', steps.vars.outputs.run-url) }}
-
-  #           ${{ format('- {0} Terraform Init', steps.init.outcome == 'success' && ':white_check_mark:' || ':x:') }}
-
-  #           ${{ format('- {0} Terraform Validate', steps.validate.outcome == 'success' && ':white_check_mark:' || ':x:') }}
-
-  #           ${{ format('- {0} Terraform Apply', steps.apply.outcome == 'success' && ':white_check_mark:' || ':x:') }}
-
-  #           ${{ format('- {0} Run k6 Smoke Test', steps.run-smoke-test.outcome == 'success' && ':white_check_mark:' || ':x:') }}
-
-  #           ${{ github.event.client_payload.slash_command.args.named.destroy != 'false' && format('- {0} Terraform Destroy', steps.destroy.outcome == 'success' && ':white_check_mark:' || ':x:') || '' }}
+  private_active_active:
+    name: Run tf-test on Private Active/Active
+    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'private-active-active')  || contains(fromJSON('["all", "private-active-active"]'), inputs.on_demand_scenario) }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      WORK_DIR_PATH: ./tests/private-active-active
+      K6_WORK_DIR_PATH: ./tests/tfe-load-test
+    steps:
+      - name: Create URL to the run output
+        id: vars
+        run: echo ::set-output name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+
+      - name: Checkout Pull Request Branch
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+        with:
+          repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.client_payload.pull_request.head.sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
+
+      - name: Set Terraform Module Source
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        env:
+          LOGIN: ${{ github.event.client_payload.pull_request.head.repo.owner.login }}
+          NAME: ${{ github.event.client_payload.pull_request.head.repo.name }}
+          SHA: ${{ github.event.client_payload.pull_request.head.sha }}
+        run: |
+          sed --in-place "s/source = \"..\/..\"/source = \"github.com\/$LOGIN\/$NAME?ref=$SHA\"/" main.tf
+          sed --in-place "s/source = \"..\/..\/fixtures\/test_proxy\"/source = \"github.com\/$LOGIN\/$NAME\/\/fixtures\/test_proxy?ref=$SHA\"/" main.tf
+
+      - name: Checkout TFE Load Test
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+        with:
+          path: ${{ env.K6_WORK_DIR_PATH }}
+          repository: hashicorp/tfe-load-test
+          token: ${{ secrets.GH_TFE_LOAD_TEST_TOKEN }}
+          persist-credentials: false
+
+      - name: Install required tools
+        working-directory: ${{ env.K6_WORK_DIR_PATH }}
+        env:
+          K6_URL: https://github.com/loadimpact/k6/releases/download/v0.31.1/k6-v0.31.1-linux64.tar.gz
+        run: |
+          sudo apt-get install jq
+          curl -L $K6_URL | tar -xz --strip-components=1
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          cli_config_credentials_hostname: 'app.terraform.io'
+          cli_config_credentials_token: ${{ secrets.PRIVATE_ACTIVE_ACTIVE_TFC_TOKEN }}
+          terraform_version: 1.1.7
+          terraform_wrapper: true
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@62d4898025f6041e16b1068643bfc5a696863587 # v1.1.0
+
+      - name: Terraform Init
+        id: init
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        run: terraform init -input=false -no-color
+
+      - name: Write Terraform Variables
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        run: |
+          cat <<EOF > github.auto.tfvars
+          iact_subnet_list = ["( dig +short @resolver1.opendns.com myip.opendns.com )/32"]
+          existing_service_account_id = "${{ secrets.GOOGLE_SERVICE_ACCOUNT }}"
+          tfe = {
+            hostname     = "${{ secrets.TFE_HOSTNAME }}"
+            organization = "${{ secrets.TFE_ORGANIZATION }}"
+            token        = "${{ secrets.TFE_TOKEN }}"
+            workspace    = "${{ secrets.TFE_WORKSPACE }}"
+          }
+          EOF
+
+      - name: Terraform Validate
+        id: validate
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        run: terraform validate -no-color
+
+      - name: Terraform Apply
+        id: apply
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        run: terraform apply -auto-approve -input=false -no-color
+
+      - name: Retrieve Health Check URL
+        id: retrieve-health-check-url
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        run: |
+          terraform output -no-color -raw health_check_url
+
+      - name: Retrieve Instance Name
+        id: retrieve-instance-name
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        run: |
+          terraform output -no-color -raw proxy_instance_name
+
+      - name: Retrieve Instance Zone
+        id: retrieve-instance-zone
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        run: |
+          terraform output -no-color -raw proxy_instance_zone
+
+      - name: Increasing the TCP Upload Bandwidth
+        id: increasing-the-tcp-upload-bandwidth-paa
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        run: |
+          $(gcloud info --format="value(basic.python_location)") -m pip install numpy
+          export CLOUDSDK_PYTHON_SITEPACKAGES=1
+
+      - name: Start SOCKS5 Proxy
+        env:
+          INSTANCE_NAME: ${{ steps.retrieve-instance-name.outputs.stdout }}
+          INSTANCE_ZONE: ${{ steps.retrieve-instance-zone.outputs.stdout }}
+        run: |
+          gcloud compute ssh \
+          --quiet \
+          --ssh-key-expire-after="1440m" \
+          --tunnel-through-iap \
+          --zone="$INSTANCE_ZONE" \
+          "$INSTANCE_NAME" \
+          -- -f -N -p 22 -D localhost:5000
+
+      - name: Wait For TFE
+        id: wait-for-tfe
+        timeout-minutes: 25
+        run: |
+          echo "Curling \`health_check_url\` for a return status of 200..."
+          while ! curl \
+            -sfS --max-time 5 --proxy socks5://localhost:5000 \
+             ${{ steps.retrieve-health-check-url.outputs.stdout }}; \
+            do sleep 5; done
+
+      - name: Retrieve TFE URL
+        id: retrieve-tfe-url
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        run: |
+          terraform output -no-color -raw tfe_url
+
+      - name: Retrieve IACT URL
+        id: retrieve-iact-url
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        run: |
+          terraform output -no-color -raw iact_url
+
+      - name: Retrieve IACT
+        id: retrieve-iact
+        run: |
+          token=$(curl --fail --retry 5 --verbose --proxy socks5://localhost:5000 "${{ steps.retrieve-iact-url.outputs.stdout }}")
+          echo "::set-output name=token::$token"
+
+      - name: Retrieve Initial Admin User URL
+        id: retrieve-initial-admin-user-url
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        run: |
+          terraform output -no-color -raw initial_admin_user_url
+
+      - name: Create Admin in TFE
+        id: create-admin
+        env:
+          TFE_PASSWORD: ${{ secrets.TFE_PASSWORD }}
+          IAU_URL: ${{ steps.retrieve-initial-admin-user-url.outputs.stdout }}
+          IACT_TOKEN: ${{ steps.retrieve-iact.outputs.token }}
+        run: |
+          echo \
+            '{"username": "test", "email": "tf-onprem-team@hashicorp.com", "password": "$TFE_PASSWORD"}' \
+            > ./payload.json
+          response=$( \
+            curl \
+            --fail \
+            --retry 15 \
+            --verbose \
+            --header 'Content-Type: application/json' \
+            --data @./payload.json \
+            --proxy socks5://localhost:5000 \
+            "$IAU_URL"?token="$IACT_TOKEN")
+          echo "::set-output name=response::$response"
+
+      - name: Retrieve Admin Token
+        id: retrieve-admin-token
+        run: |
+          token=$(echo "${{ steps.create-admin.outputs.response }}" | jq --raw-output '.token')
+          echo "::set-output name=token::$token"
+
+      - name: Run k6 Smoke Test
+        id: run-smoke-test
+        working-directory: ${{ env.K6_WORK_DIR_PATH }}
+        env:
+          K6_PATHNAME: "./k6"
+          TFE_URL: "${{ steps.retrieve-tfe-url.outputs.stdout }}"
+          TFE_API_TOKEN: "${{ steps.retrieve-admin-token.outputs.token }}"
+          TFE_EMAIL: tf-onprem-team@hashicorp.com
+          http_proxy: socks5://localhost:5000/
+          https_proxy: socks5://localhost:5000/
+        run: |
+          make smoke-test
+
+      - name: Terraform Destroy
+        id: destroy
+        if: ${{ always() && github.event.client_payload.slash_command.args.named.destroy != 'false' }}
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        run: terraform destroy -auto-approve -input=false -no-color
+
+      - name: Update comment
+        if: ${{ always() }}
+        uses: peter-evans/create-or-update-comment@3383acd359705b10cb1eeef05c0e88c056ea4666 # v3.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+          body: |
+            ${{ format('### {0} Terraform Private Active/Active Test Report', job.status == 'success' && ':white_check_mark:' || ':x:') }}
+
+            ${{ format(':link: [Action Summary Page]({0})', steps.vars.outputs.run-url) }}
+
+            ${{ format('- {0} Terraform Init', steps.init.outcome == 'success' && ':white_check_mark:' || ':x:') }}
+
+            ${{ format('- {0} Terraform Validate', steps.validate.outcome == 'success' && ':white_check_mark:' || ':x:') }}
+
+            ${{ format('- {0} Terraform Apply', steps.apply.outcome == 'success' && ':white_check_mark:' || ':x:') }}
+
+            ${{ format('- {0} Run k6 Smoke Test', steps.run-smoke-test.outcome == 'success' && ':white_check_mark:' || ':x:') }}
+
+            ${{ github.event.client_payload.slash_command.args.named.destroy != 'false' && format('- {0} Terraform Destroy', steps.destroy.outcome == 'success' && ':white_check_mark:' || ':x:') || '' }}
+
+  private_tcp_active_active:
+    name: Run tf-test on Private TCP Active/Active
+    if: ${{ contains(github.event.client_payload.slash_command.args.unnamed.all, 'all') || contains(github.event.client_payload.slash_command.args.unnamed.all, 'private-tcp-active-active')  || contains(fromJSON('["all", "private-tcp-active-active"]'), inputs.on_demand_scenario) }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      WORK_DIR_PATH: ./tests/private-tcp-active-active
+      K6_WORK_DIR_PATH: ./tests/tfe-load-test
+    steps:
+      - name: Create URL to the run output
+        id: vars
+        run: echo ::set-output name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+
+      - name: Checkout Pull Request Branch
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+        with:
+          repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.client_payload.pull_request.head.sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
+
+      - name: Set Terraform Module Source
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        env:
+          LOGIN: ${{ github.event.client_payload.pull_request.head.repo.owner.login }}
+          NAME: ${{ github.event.client_payload.pull_request.head.repo.name }}
+          SHA: ${{ github.event.client_payload.pull_request.head.sha }}
+        run: |
+          sed --in-place "s/source = \"..\/..\"/source = \"github.com\/$LOGIN\/$NAME?ref=$SHA\"/" main.tf
+          sed --in-place "s/source = \"..\/..\/fixtures\/test_proxy\"/source = \"github.com\/$LOGIN\/$NAME\/\/fixtures\/test_proxy?ref=$SHA\"/" main.tf
+
+      - name: Checkout TFE Load Test
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+        with:
+          path: ${{ env.K6_WORK_DIR_PATH }}
+          repository: hashicorp/tfe-load-test
+          token: ${{ secrets.GH_TFE_LOAD_TEST_TOKEN }}
+          persist-credentials: false
+
+      - name: Install required tools
+        working-directory: ${{ env.K6_WORK_DIR_PATH }}
+        env:
+          K6_URL: https://github.com/loadimpact/k6/releases/download/v0.31.1/k6-v0.31.1-linux64.tar.gz
+        run: |
+          sudo apt-get install jq
+          curl -L $K6_URL | tar -xz --strip-components=1
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          cli_config_credentials_hostname: 'app.terraform.io'
+          cli_config_credentials_token: ${{ secrets.PRIVATE_TCP_ACTIVE_ACTIVE_TFC_TOKEN }}
+          terraform_version: 1.1.7
+          terraform_wrapper: true
+   
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@62d4898025f6041e16b1068643bfc5a696863587 # v1.1.0
+
+      - name: Terraform Init
+        id: init
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        run: terraform init -input=false -no-color
+
+      - name: Write Terraform Variables
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        run: |
+          cat <<EOF > github.auto.tfvars
+          iact_subnet_list = ["( dig +short @resolver1.opendns.com myip.opendns.com )/32"]
+          existing_service_account_id = "${{ secrets.GOOGLE_SERVICE_ACCOUNT }}"
+          tfe = {
+            hostname     = "${{ secrets.TFE_HOSTNAME }}"
+            organization = "${{ secrets.TFE_ORGANIZATION }}"
+            token        = "${{ secrets.TFE_TOKEN }}"
+            workspace    = "${{ secrets.TFE_WORKSPACE }}"
+          }
+          EOF
+
+      - name: Terraform Validate
+        id: validate
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        run: terraform validate -no-color
+
+      - name: Terraform Apply
+        id: apply
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        run: terraform apply -auto-approve -input=false -no-color
+
+      - name: Retrieve Health Check URL
+        id: retrieve-health-check-url
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        run: |
+          terraform output -no-color -raw health_check_url
+
+      - name: Retrieve Instance Name
+        id: retrieve-instance-name
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        run: |
+          terraform output -no-color -raw proxy_instance_name
+
+      - name: Retrieve Instance Zone
+        id: retrieve-instance-zone
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        run: |
+          terraform output -no-color -raw proxy_instance_zone
+
+
+      - name: Increasing the TCP Upload Bandwidth
+        id: increasing-the-tcp-upload-bandwidth-ptaa
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        run: |
+          $(gcloud info --format="value(basic.python_location)") -m pip install numpy
+          export CLOUDSDK_PYTHON_SITEPACKAGES=1
+
+      - name: Start SOCKS5 Proxy
+        run: |
+          gcloud compute ssh \
+          --quiet \
+          --ssh-key-expire-after="1440m" \
+          --tunnel-through-iap \
+          --zone="${{ steps.retrieve-instance-zone.outputs.stdout }}" \
+          "${{ steps.retrieve-instance-name.outputs.stdout }}" \
+          -- \
+          -o 'ServerAliveInterval 5' \
+          -o 'ServerAliveCountMax 3' \
+          -f -N -p 22 -D localhost:5000
+
+      - name: Wait For TFE
+        id: wait-for-tfe
+        timeout-minutes: 25
+        run: |
+          echo "Curling \`health_check_url\` for a return status of 200..."
+          while ! curl \
+            -sfS --max-time 5 --proxy socks5://localhost:5000 \
+            ${{ steps.retrieve-health-check-url.outputs.stdout }}; \
+            do sleep 5; done
+
+      - name: Retrieve TFE URL
+        id: retrieve-tfe-url
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        run: |
+          terraform output -no-color -raw tfe_url
+
+      - name: Retrieve IACT URL
+        id: retrieve-iact-url
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        run: |
+          terraform output -no-color -raw iact_url
+
+      - name: Retrieve IACT
+        id: retrieve-iact
+        run: |
+          token=$(curl --fail --retry 5 --verbose --proxy socks5://localhost:5000 "${{ steps.retrieve-iact-url.outputs.stdout }}")
+          echo "::set-output name=token::$token"
+
+      - name: Retrieve Initial Admin User URL
+        id: retrieve-initial-admin-user-url
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        run: |
+          terraform output -no-color -raw initial_admin_user_url
+
+      - name: Create Admin in TFE
+        id: create-admin
+        env:
+          TFE_PASSWORD: ${{ secrets.TFE_PASSWORD }}
+          IAU_URL: ${{ steps.retrieve-initial-admin-user-url.outputs.stdout }}
+          IACT_TOKEN: ${{ steps.retrieve-iact.outputs.token }}
+        run: |
+          echo \
+            '{"username": "test", "email": "tf-onprem-team@hashicorp.com", "password": "$TFE_PASSWORD"}' \
+            > ./payload.json
+          response=$( \
+            curl \
+            --fail \
+            --retry 5 \
+            --verbose \
+            --header 'Content-Type: application/json' \
+            --data @./payload.json \
+            --proxy socks5://localhost:5000 \
+            "$IAU_URL"?token="$IACT_TOKEN")
+          echo "::set-output name=response::$response"
+
+      - name: Retrieve Admin Token
+        id: retrieve-admin-token
+        run: |
+          token=$(echo "${{ steps.create-admin.outputs.response }}" | jq --raw-output '.token')
+          echo "::set-output name=token::$token"
+
+      - name: Run k6 Smoke Test
+        id: run-smoke-test
+        working-directory: ${{ env.K6_WORK_DIR_PATH }}
+        env:
+          K6_PATHNAME: "./k6"
+          TFE_URL: "${{ steps.retrieve-tfe-url.outputs.stdout }}"
+          TFE_API_TOKEN: "${{ steps.retrieve-admin-token.outputs.token }}"
+          TFE_EMAIL: tf-onprem-team@hashicorp.com
+          http_proxy: socks5://localhost:5000/
+          https_proxy: socks5://localhost:5000/
+        run: |
+          make smoke-test
+
+      - name: Terraform Destroy
+        id: destroy
+        if: ${{ always() && github.event.client_payload.slash_command.args.named.destroy != 'false' }}
+        working-directory: ${{ env.WORK_DIR_PATH }}
+        run: terraform destroy -auto-approve -input=false -no-color
+
+      - name: Update comment
+        if: ${{ always() }}
+        uses: peter-evans/create-or-update-comment@3383acd359705b10cb1eeef05c0e88c056ea4666 # v3.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+          body: |
+            ${{ format('### {0} Terraform Private TCP Active/Active Test Report', job.status == 'success' && ':white_check_mark:' || ':x:') }}
+
+            ${{ format(':link: [Action Summary Page]({0})', steps.vars.outputs.run-url) }}
+
+            ${{ format('- {0} Terraform Init', steps.init.outcome == 'success' && ':white_check_mark:' || ':x:') }}
+
+            ${{ format('- {0} Terraform Validate', steps.validate.outcome == 'success' && ':white_check_mark:' || ':x:') }}
+
+            ${{ format('- {0} Terraform Apply', steps.apply.outcome == 'success' && ':white_check_mark:' || ':x:') }}
+
+            ${{ format('- {0} Run k6 Smoke Test', steps.run-smoke-test.outcome == 'success' && ':white_check_mark:' || ':x:') }}
+
+            ${{ github.event.client_payload.slash_command.args.named.destroy != 'false' && format('- {0} Terraform Destroy', steps.destroy.outcome == 'success' && ':white_check_mark:' || ':x:') || '' }}

--- a/tests/private-active-active/versions.tf
+++ b/tests/private-active-active/versions.tf
@@ -3,7 +3,13 @@
 
 terraform {
   required_version = ">= 0.14"
+  backend "remote" {
+    organization = "terraform-enterprise-modules-test"
 
+    workspaces {
+      name = "google-private-active-active"
+    }
+  }
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/tests/private-tcp-active-active/versions.tf
+++ b/tests/private-tcp-active-active/versions.tf
@@ -3,7 +3,13 @@
 
 terraform {
   required_version = ">= 0.14"
+  backend "remote" {
+    organization = "terraform-enterprise-modules-test"
 
+    workspaces {
+      name = "google-private-tcp-active-active"
+    }
+  }
   required_providers {
     google = {
       source  = "hashicorp/google"


### PR DESCRIPTION
## Background

#240 

This branch hearkens back to a simpler time when we hardcoded the backend config directly into the test module. Because the tests have been broken for so long, I'm opting to simplify. This means that the tests that we normally use for `ptfe-replicated` testing will not run in the slash commands any longer (they were broken anyway, so you're not really losing much here.) Those removed from being able to run in this repo's GHA are:
* standalone-mounted-disk
* standalone-external-rhel8-worker