### PR TITLE
test

### DIFF
--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -82,7 +82,6 @@ jobs:
         run: |
           cat <<EOF > github.auto.tfvars
           iact_subnet_list = ["( dig +short @resolver1.opendns.com myip.opendns.com )/32"]
-          existing_service_account_id = "${{ secrets.GOOGLE_SERVICE_ACCOUNT }}"
           tfe = {
             hostname     = "${{ secrets.TFE_HOSTNAME }}"
             organization = "${{ secrets.TFE_ORGANIZATION }}"
@@ -282,7 +281,6 @@ jobs:
         run: |
           cat <<EOF > github.auto.tfvars
           iact_subnet_list = ["( dig +short @resolver1.opendns.com myip.opendns.com )/32"]
-          existing_service_account_id = "${{ secrets.GOOGLE_SERVICE_ACCOUNT }}"
           tfe = {
             hostname     = "${{ secrets.TFE_HOSTNAME }}"
             organization = "${{ secrets.TFE_ORGANIZATION }}"
@@ -517,7 +515,6 @@ jobs:
         run: |
           cat <<EOF > github.auto.tfvars
           iact_subnet_list = ["( dig +short @resolver1.opendns.com myip.opendns.com )/32"]
-          existing_service_account_id = "${{ secrets.GOOGLE_SERVICE_ACCOUNT }}"
           tfe = {
             hostname     = "${{ secrets.TFE_HOSTNAME }}"
             organization = "${{ secrets.TFE_ORGANIZATION }}"

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -128,7 +128,7 @@ jobs:
       - name: Retrieve IACT
         id: retrieve-iact
         run: |
-          token=$(curl --fail --retry 5 --verbose "${{ steps.retrieve-iact-url.outputs.stdout }}")
+          token=$(curl --fail --retry 15 --verbose "${{ steps.retrieve-iact-url.outputs.stdout }}")
           echo "::set-output name=token::$token"
 
       - name: Retrieve Initial Admin User URL
@@ -362,7 +362,7 @@ jobs:
       - name: Retrieve IACT
         id: retrieve-iact
         run: |
-          token=$(curl --fail --retry 5 --verbose --proxy socks5://localhost:5000 "${{ steps.retrieve-iact-url.outputs.stdout }}")
+          token=$(curl --fail --retry 15 --verbose --proxy socks5://localhost:5000 "${{ steps.retrieve-iact-url.outputs.stdout }}")
           echo "::set-output name=token::$token"
 
       - name: Retrieve Initial Admin User URL
@@ -597,7 +597,7 @@ jobs:
       - name: Retrieve IACT
         id: retrieve-iact
         run: |
-          token=$(curl --fail --retry 5 --verbose --proxy socks5://localhost:5000 "${{ steps.retrieve-iact-url.outputs.stdout }}")
+          token=$(curl --fail --retry 15 --verbose --proxy socks5://localhost:5000 "${{ steps.retrieve-iact-url.outputs.stdout }}")
           echo "::set-output name=token::$token"
 
       - name: Retrieve Initial Admin User URL

--- a/tests/private-active-active/variables.tf
+++ b/tests/private-active-active/variables.tf
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 variable "consolidated_services" {
-  default     = false
+  default     = true
   type        = bool
   description = "(Required) True if TFE uses consolidated services."
 }

--- a/tests/private-tcp-active-active/variables.tf
+++ b/tests/private-tcp-active-active/variables.tf
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 variable "consolidated_services" {
-  default     = false
+  default     = true
   type        = bool
   description = "(Required) True if TFE uses consolidated services."
 }

--- a/tests/public-active-active/variables.tf
+++ b/tests/public-active-active/variables.tf
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 variable "consolidated_services" {
-  default     = false
+  default     = true
   type        = bool
   description = "(Required) True if TFE uses consolidated services."
 }


### PR DESCRIPTION
## Background

#240 

* The `existing_service_account_id` is already managed through TFC variables and should not be passed in through GHA.
* Sometimes the curl for the iact token isn't quiet ready after the healthcheck is up, so I added some extra retries.
* The `consolidated_services` mode is much faster to spin up, so I defaulted that.