### PR TITLE
upgrade redis to 6.0

### DIFF
--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -14,7 +14,7 @@ resource "google_redis_instance" "redis" {
   authorized_network = var.service_networking_connection.network
   connect_mode       = "PRIVATE_SERVICE_ACCESS"
 
-  redis_version = "REDIS_5_0"
+  redis_version = "REDIS_6_0"
   display_name  = "${var.namespace} TFE Instance"
 
   labels = var.labels


### PR DESCRIPTION
## Background

This pull request upgrades the officially supported redis version to 6 because 5 will be deprecated.
