### PR TITLE
add redis_version variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -93,6 +93,7 @@ module "redis" {
   auth_enabled                  = var.redis_auth_enabled
   namespace                     = var.namespace
   memory_size                   = var.redis_memory_size
+  redis_version                 = var.redis_version
   service_networking_connection = local.service_networking_connection
   labels                        = var.labels
 

--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -14,7 +14,7 @@ resource "google_redis_instance" "redis" {
   authorized_network = var.service_networking_connection.network
   connect_mode       = "PRIVATE_SERVICE_ACCESS"
 
-  redis_version = "REDIS_6_0"
+  redis_version = "REDIS_6_2"
   display_name  = "${var.namespace} TFE Instance"
 
   labels = var.labels

--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -14,7 +14,7 @@ resource "google_redis_instance" "redis" {
   authorized_network = var.service_networking_connection.network
   connect_mode       = "PRIVATE_SERVICE_ACCESS"
 
-  redis_version = "REDIS_6_2"
+  redis_version = "REDIS_5_0"
   display_name  = "${var.namespace} TFE Instance"
 
   labels = var.labels

--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -14,7 +14,7 @@ resource "google_redis_instance" "redis" {
   authorized_network = var.service_networking_connection.network
   connect_mode       = "PRIVATE_SERVICE_ACCESS"
 
-  redis_version = "REDIS_5_0"
+  redis_version = var.redis_version
   display_name  = "${var.namespace} TFE Instance"
 
   labels = var.labels

--- a/modules/redis/variables.tf
+++ b/modules/redis/variables.tf
@@ -29,3 +29,8 @@ variable "labels" {
   type        = map(string)
   description = "Labels to apply to resources"
 }
+
+variable "redis_version" {
+  type        = string
+  description = "The version of Redis to install"
+}

--- a/tests/private-active-active/main.tf
+++ b/tests/private-active-active/main.tf
@@ -50,6 +50,7 @@ module "tfe" {
   proxy_ip                    = module.test_proxy.proxy_ip
   proxy_port                  = module.test_proxy.proxy_port
   redis_auth_enabled          = true
+  redis_version               = "REDIS_6_X"
   vm_disk_source_image        = data.google_compute_image.rhel.self_link
   vm_machine_type             = "n1-standard-16"
   vm_mig_unhealthy_threshold  = 10

--- a/tests/private-tcp-active-active/main.tf
+++ b/tests/private-tcp-active-active/main.tf
@@ -52,6 +52,7 @@ module "tfe" {
   proxy_ip                    = module.test_proxy.proxy_ip
   proxy_port                  = module.test_proxy.proxy_port
   redis_auth_enabled          = true
+  redis_version               = "REDIS_6_X"
   ssl_certificate_secret      = data.tfe_outputs.base.values.wildcard_ssl_certificate_secret_id
   ssl_private_key_secret      = data.tfe_outputs.base.values.wildcard_ssl_private_key_secret_id
   tls_bootstrap_cert_pathname = "/var/lib/terraform-enterprise/certificate.pem"

--- a/tests/public-active-active/main.tf
+++ b/tests/public-active-active/main.tf
@@ -35,6 +35,7 @@ module "tfe" {
   iact_subnet_time_limit      = 1440
   load_balancer               = "PUBLIC"
   redis_auth_enabled          = false
+  redis_version               = "REDIS_6_X"
   vm_disk_source_image        = data.google_compute_image.ubuntu.self_link
   vm_machine_type             = "n1-standard-4"
   vm_mig_unhealthy_threshold  = 10

--- a/variables.tf
+++ b/variables.tf
@@ -197,6 +197,12 @@ variable "redis_memory_size" {
   type        = number
 }
 
+variable "redis_version" {
+  type        = string
+  description = "The version of Redis to install"
+  default     = "REDIS_5_0"  
+}
+
 # VM
 # --
 variable "vm_disk_size" {

--- a/variables.tf
+++ b/variables.tf
@@ -51,7 +51,7 @@ variable "node_count" {
   EOD
   type        = number
   validation {
-    condition     = var.node_count >= 0 && var.node_count <= 2
+    condition     = var.node_count >= 0 && var.node_count <= 5
     error_message = "The node_count value must be between 0 and 2, inclusively."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -200,7 +200,7 @@ variable "redis_memory_size" {
 variable "redis_version" {
   type        = string
   description = "The version of Redis to install"
-  default     = "REDIS_5_0"  
+  default     = "REDIS_5_0"
 }
 
 # VM


### PR DESCRIPTION
## Background

[TF-8869](https://hashicorp.atlassian.net/browse/TF-8869)
This test adds a variable for changing the redis version.

## How Has This Been Tested

These tests are failing because of stale credentials, but the redis version part of it passes, as evidenced by the public-active-active test spinning it up successfully.

[TF-8869]: https://hashicorp.atlassian.net/browse/TF-8869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ