### PR TITLE
specifiy redis version

### DIFF
--- a/tests/private-active-active/main.tf
+++ b/tests/private-active-active/main.tf
@@ -50,7 +50,7 @@ module "tfe" {
   proxy_ip                    = module.test_proxy.proxy_ip
   proxy_port                  = module.test_proxy.proxy_port
   redis_auth_enabled          = true
-  redis_version               = "REDIS_6_X"
+  redis_version               = "REDIS_6_2_13"
   vm_disk_source_image        = data.google_compute_image.rhel.self_link
   vm_machine_type             = "n1-standard-16"
   vm_mig_unhealthy_threshold  = 10

--- a/tests/private-active-active/main.tf
+++ b/tests/private-active-active/main.tf
@@ -50,7 +50,7 @@ module "tfe" {
   proxy_ip                    = module.test_proxy.proxy_ip
   proxy_port                  = module.test_proxy.proxy_port
   redis_auth_enabled          = true
-  redis_version               = "REDIS_6_2_13"
+  redis_version               = "REDIS_7_0"
   vm_disk_source_image        = data.google_compute_image.rhel.self_link
   vm_machine_type             = "n1-standard-16"
   vm_mig_unhealthy_threshold  = 10

--- a/tests/private-tcp-active-active/main.tf
+++ b/tests/private-tcp-active-active/main.tf
@@ -52,7 +52,7 @@ module "tfe" {
   proxy_ip                    = module.test_proxy.proxy_ip
   proxy_port                  = module.test_proxy.proxy_port
   redis_auth_enabled          = true
-  redis_version               = "REDIS_6_X"
+  redis_version               = "REDIS_6_2_13"
   ssl_certificate_secret      = data.tfe_outputs.base.values.wildcard_ssl_certificate_secret_id
   ssl_private_key_secret      = data.tfe_outputs.base.values.wildcard_ssl_private_key_secret_id
   tls_bootstrap_cert_pathname = "/var/lib/terraform-enterprise/certificate.pem"

--- a/tests/private-tcp-active-active/main.tf
+++ b/tests/private-tcp-active-active/main.tf
@@ -52,7 +52,7 @@ module "tfe" {
   proxy_ip                    = module.test_proxy.proxy_ip
   proxy_port                  = module.test_proxy.proxy_port
   redis_auth_enabled          = true
-  redis_version               = "REDIS_6_2_13"
+  redis_version               = "REDIS_7_0"
   ssl_certificate_secret      = data.tfe_outputs.base.values.wildcard_ssl_certificate_secret_id
   ssl_private_key_secret      = data.tfe_outputs.base.values.wildcard_ssl_private_key_secret_id
   tls_bootstrap_cert_pathname = "/var/lib/terraform-enterprise/certificate.pem"

--- a/tests/public-active-active/main.tf
+++ b/tests/public-active-active/main.tf
@@ -35,7 +35,7 @@ module "tfe" {
   iact_subnet_time_limit      = 1440
   load_balancer               = "PUBLIC"
   redis_auth_enabled          = false
-  redis_version               = "REDIS_6_X"
+  redis_version               = "REDIS_6_2_13"
   vm_disk_source_image        = data.google_compute_image.ubuntu.self_link
   vm_machine_type             = "n1-standard-4"
   vm_mig_unhealthy_threshold  = 10

--- a/tests/public-active-active/main.tf
+++ b/tests/public-active-active/main.tf
@@ -35,7 +35,7 @@ module "tfe" {
   iact_subnet_time_limit      = 1440
   load_balancer               = "PUBLIC"
   redis_auth_enabled          = false
-  redis_version               = "REDIS_6_2_13"
+  redis_version               = "REDIS_7_0"
   vm_disk_source_image        = data.google_compute_image.ubuntu.self_link
   vm_machine_type             = "n1-standard-4"
   vm_mig_unhealthy_threshold  = 10

--- a/variables.tf
+++ b/variables.tf
@@ -200,7 +200,7 @@ variable "redis_memory_size" {
 variable "redis_version" {
   type        = string
   description = "The version of Redis to install"
-  default     = "REDIS_5_0"
+  default     = "REDIS_7_0"
 }
 
 # VM


### PR DESCRIPTION
## Background

[Jira TF-8869](https://hashicorp.atlassian.net/browse/TF-8869) 
Relates: #264 

Redis creation fails with unspecified version pinning. This branch uses the pinned 7.0 version specified [here](https://cloud.google.com/memorystore/docs/redis/supported-versions) and approved [here on the docs](https://developer.hashicorp.com/terraform/enterprise/install/automated/active-active#appendix-2-gcp-memorystore-for-redis).

## Tests

The test using `REDIS_6_X` [failed](https://github.com/hashicorp/terraform-google-terraform-enterprise/pull/265#issuecomment-1695970659) because it defaulted down to `6.0`, so I simply went up to `7.0` instead of pinning to 6 since we recommend v7. 

The proceeding three tests used `REDIS_7_0`, and the Redis creation in each passed. 

The failure in the `private-active-active` test is due to the health_check not passing in time before the scale set instances were rolled (I SSHed to the instance and saw that it was coming up just fine, but the health check timed out), not related to the Redis version.

The [failure](https://github.com/hashicorp/terraform-google-terraform-enterprise/actions/runs/6002552203/job/16279119135#step:13:1380) in the `private-tcp-active-active` is due to an existing [issue in the service account](https://github.com/hashicorp/terraform-google-terraform-enterprise/actions/runs/6002552203/job/16279119135#step:13:1380) that needs to be remediated in a follow-up PR but has nothing to do with the Redis version.
