### PR TITLE
update setup-gcloud actions

### DIFF
--- a/.github/workflows/handler-destroy.yml
+++ b/.github/workflows/handler-destroy.yml
@@ -62,9 +62,10 @@ jobs:
       - name: Write Terraform Variables
         working-directory: ${{ env.WORK_DIR_PATH }}
         run: |
+          iact_subnet=$( dig +short @resolver1.opendns.com myip.opendns.com )
           cat <<EOF > github.auto.tfvars
-          iact_subnet_list = ["( dig +short @resolver1.opendns.com myip.opendns.com )/32"]
-          existing_service_account_id = "${{ secrets.GOOGLE_SERVICE_ACCOUNT }}"
+          iact_subnet_list = ["$iact_subnet/32"]
+          consolidated_services = true
           tfe = {
             hostname     = "${{ secrets.TFE_HOSTNAME }}"
             organization = "${{ secrets.TFE_ORGANIZATION }}"
@@ -76,6 +77,9 @@ jobs:
       - name: Terraform Destroy
         id: destroy
         working-directory: ${{ env.WORK_DIR_PATH }}
+        env:
+          TFE_HOSTNAME: ${{ secrets.TFE_HOSTNAME }}
+          TFE_TOKEN: ${{ secrets.TFE_TOKEN }}
         run: terraform destroy -auto-approve -input=false -no-color
 
       - name: Update comment
@@ -146,7 +150,6 @@ jobs:
         run: |
           cat <<EOF > github.auto.tfvars
           iact_subnet_list = ["( dig +short @resolver1.opendns.com myip.opendns.com )/32"]
-          existing_service_account_id = "${{ secrets.GOOGLE_SERVICE_ACCOUNT }}"
           tfe = {
             hostname     = "${{ secrets.TFE_HOSTNAME }}"
             organization = "${{ secrets.TFE_ORGANIZATION }}"
@@ -226,9 +229,10 @@ jobs:
       - name: Write Terraform Variables
         working-directory: ${{ env.WORK_DIR_PATH }}
         run: |
+          iact_subnet=$( dig +short @resolver1.opendns.com myip.opendns.com )
           cat <<EOF > github.auto.tfvars
-          iact_subnet_list = ["( dig +short @resolver1.opendns.com myip.opendns.com )/32"]
-          existing_service_account_id = "${{ secrets.GOOGLE_SERVICE_ACCOUNT }}"
+          iact_subnet_list = ["$iact_subnet/32"]
+          consolidated_services = true
           tfe = {
             hostname     = "${{ secrets.TFE_HOSTNAME }}"
             organization = "${{ secrets.TFE_ORGANIZATION }}"
@@ -324,9 +328,10 @@ jobs:
       - name: Write Terraform Variables
         working-directory: ${{ env.WORK_DIR_PATH }}
         run: |
+          iact_subnet=$( dig +short @resolver1.opendns.com myip.opendns.com )
           cat <<EOF > github.auto.tfvars
-          iact_subnet_list = ["( dig +short @resolver1.opendns.com myip.opendns.com )/32"]
-          existing_service_account_id = "${{ secrets.GOOGLE_SERVICE_ACCOUNT }}"
+          iact_subnet_list = ["$iact_subnet/32"]
+          consolidated_services = true
           tfe = {
             hostname     = "${{ secrets.TFE_HOSTNAME }}"
             organization = "${{ secrets.TFE_ORGANIZATION }}"
@@ -422,9 +427,10 @@ jobs:
       - name: Write Terraform Variables
         working-directory: ${{ env.WORK_DIR_PATH }}
         run: |
+          iact_subnet=$( dig +short @resolver1.opendns.com myip.opendns.com )
           cat <<EOF > github.auto.tfvars
-          iact_subnet_list = ["( dig +short @resolver1.opendns.com myip.opendns.com )/32"]
-          existing_service_account_id = "${{ secrets.GOOGLE_SERVICE_ACCOUNT }}"
+          iact_subnet_list = ["$iact_subnet/32"]
+          consolidated_services = true
           tfe = {
             hostname     = "${{ secrets.TFE_HOSTNAME }}"
             organization = "${{ secrets.TFE_ORGANIZATION }}"

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -272,7 +272,7 @@ jobs:
           credentials_json: ${{ secrets.GCP_TUNNELING_CREDENTIALS }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@62d4898025f6041e16b1068643bfc5a696863587 # v1.1.0
 
       - name: Terraform Init
         id: init
@@ -509,7 +509,7 @@ jobs:
           credentials_json: ${{ secrets.GCP_TUNNELING_CREDENTIALS }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@62d4898025f6041e16b1068643bfc5a696863587 # v1.1.0
 
       - name: Terraform Init
         id: init

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -284,6 +284,7 @@ jobs:
         working-directory: ${{ env.WORK_DIR_PATH }}
         run: |
           cat <<EOF > github.auto.tfvars
+          iact_subnet_list = ["( dig +short @resolver1.opendns.com myip.opendns.com )/32"]
           tfe = {
             hostname     = "${{ secrets.TFE_HOSTNAME }}"
             organization = "${{ secrets.TFE_ORGANIZATION }}"
@@ -520,7 +521,10 @@ jobs:
       - name: Write Terraform Variables
         working-directory: ${{ env.WORK_DIR_PATH }}
         run: |
+          iact_subnet=$( dig +short @resolver1.opendns.com myip.opendns.com )
           cat <<EOF > github.auto.tfvars
+          iact_subnet_list = ["$iact_subnet/32"]
+          consolidated_services = true
           tfe = {
             hostname     = "${{ secrets.TFE_HOSTNAME }}"
             organization = "${{ secrets.TFE_ORGANIZATION }}"

--- a/.github/workflows/handler-test.yml
+++ b/.github/workflows/handler-test.yml
@@ -83,6 +83,7 @@ jobs:
           iact_subnet=$( dig +short @resolver1.opendns.com myip.opendns.com )
           cat <<EOF > github.auto.tfvars
           iact_subnet_list = ["$iact_subnet/32"]
+          consolidated_services = true
           tfe = {
             hostname     = "${{ secrets.TFE_HOSTNAME }}"
             organization = "${{ secrets.TFE_ORGANIZATION }}"
@@ -773,6 +774,7 @@ jobs:
           iact_subnet=$( dig +short @resolver1.opendns.com myip.opendns.com )
           cat <<EOF > github.auto.tfvars
           iact_subnet_list = ["$iact_subnet/32"]
+          consolidated_services = true
           tfe = {
             hostname     = "${{ secrets.TFE_HOSTNAME }}"
             organization = "${{ secrets.TFE_ORGANIZATION }}"
@@ -985,6 +987,7 @@ jobs:
           iact_subnet=$( dig +short @resolver1.opendns.com myip.opendns.com )
           cat <<EOF > github.auto.tfvars
           iact_subnet_list = ["$iact_subnet/32"]
+          consolidated_services = true
           tfe = {
             hostname     = "${{ secrets.TFE_HOSTNAME }}"
             organization = "${{ secrets.TFE_ORGANIZATION }}"


### PR DESCRIPTION
## Background

This branch:
* updates the `setup-gcloud` actions
* brings parity between the variables in the `test` and `destroy` workflows
* uses `consolidated_services` mode for tests

This will be tested after merge.