### PR TITLE
adds variables for health check options

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -244,16 +244,16 @@ module "vm_mig" {
   region            = null
 
   health_check = {
-    check_interval_sec  = 60
-    healthy_threshold   = 2
+    check_interval_sec  = var.vm_mig_check_interval_sec
+    healthy_threshold   = var.vm_mig_healthy_threshold
     host                = null
-    initial_delay_sec   = 600
+    initial_delay_sec   = var.vm_mig_initial_delay_sec
     port                = 443
     proxy_header        = null
     request             = null
     request_path        = "/_health_check"
     response            = null
-    timeout_sec         = 10
+    timeout_sec         = var.vm_mig_timeout_sec
     type                = "https"
     unhealthy_threshold = var.vm_mig_unhealthy_threshold
   }

--- a/tests/private-active-active/main.tf
+++ b/tests/private-active-active/main.tf
@@ -53,5 +53,9 @@ module "tfe" {
   redis_version               = "REDIS_7_0"
   vm_disk_source_image        = data.google_compute_image.rhel.self_link
   vm_machine_type             = "n1-standard-16"
+  vm_mig_check_interval_sec   = 300
+  vm_mig_healthy_threshold    = 1
+  vm_mig_initial_delay_sec    = 3600
+  vm_mig_timeout_sec          = 300
   vm_mig_unhealthy_threshold  = 10
 }

--- a/tests/private-tcp-active-active/main.tf
+++ b/tests/private-tcp-active-active/main.tf
@@ -59,6 +59,9 @@ module "tfe" {
   tls_bootstrap_key_pathname  = "/var/lib/terraform-enterprise/key.pem"
   vm_disk_source_image        = data.google_compute_image.rhel.self_link
   vm_machine_type             = "n1-standard-32"
+  vm_mig_check_interval_sec   = 300
+  vm_mig_healthy_threshold    = 1
+  vm_mig_initial_delay_sec    = 3600
+  vm_mig_timeout_sec          = 300
   vm_mig_unhealthy_threshold  = 10
-  # enable_monitoring           = true
 }

--- a/tests/public-active-active/main.tf
+++ b/tests/public-active-active/main.tf
@@ -38,6 +38,10 @@ module "tfe" {
   redis_version               = "REDIS_7_0"
   vm_disk_source_image        = data.google_compute_image.ubuntu.self_link
   vm_machine_type             = "n1-standard-4"
+  vm_mig_check_interval_sec   = 300
+  vm_mig_healthy_threshold    = 1
+  vm_mig_initial_delay_sec    = 3600
+  vm_mig_timeout_sec          = 300
   vm_mig_unhealthy_threshold  = 10
 
   labels = {

--- a/variables.tf
+++ b/variables.tf
@@ -271,14 +271,18 @@ variable "vm_mig_timeout_sec" {
   type        = number
   validation {
     condition     = var.vm_mig_timeout_sec >= 1 && var.vm_mig_timeout_sec <= 300
-    error_message = "The vm_mig_initial_delay_sec must be an integer between 1 and 300 and must be lower than or equal to vm_mig_check_interval_sec."
+    error_message = "The vm_mig_timeout_sec must be an integer between 1 and 300 and must be lower than or equal to vm_mig_check_interval_sec."
   }
 }
 
 variable "vm_mig_unhealthy_threshold" {
   default     = 6
-  description = "The number of sequential failed health check probe results for a backend to be considered unhealthy. Unhealthy threshold must be an integer between 1 and 10, inclusive."
+  description = "The number of sequential failed health check probe results for a backend to be considered unhealthy."
   type        = number
+  validation {
+    condition     = var.vm_mig_unhealthy_threshold >= 1 && var.vm_mig_unhealthy_threshold <= 10
+    error_message = "The vm_mig_unhealthy_threshold must be an integer between 1 and 10, inclusive."
+  }
 }
 
 variable "vm_mounted_disk_size" {

--- a/variables.tf
+++ b/variables.tf
@@ -235,9 +235,49 @@ variable "vm_metadata" {
   type        = map(string)
 }
 
+variable "vm_mig_check_interval_sec" {
+  default     = 60
+  description = "How often (in seconds) to send a health check."
+  type        = number
+  validation {
+    condition     = var.vm_mig_check_interval_sec >= 1 && var.vm_mig_check_interval_sec <= 300
+    error_message = "The vm_mig_check_interval_sec must be an integer between 1 and 300, inclusive."
+  }
+}
+
+variable "vm_mig_healthy_threshold" {
+  default     = 2
+  description = "The number of sequential successful health check probe results for a backend to be considered healthy."
+  type        = number
+  validation {
+    condition     = var.vm_mig_healthy_threshold >= 1 && var.vm_mig_healthy_threshold <= 10
+    error_message = "The vm_mig_healthy_threshold must be an integer between 1 and 10, inclusive."
+  }
+}
+
+variable "vm_mig_initial_delay_sec" {
+  default     = 600
+  description = "The number of seconds that the managed instance group waits before it applies autohealing policies to new instances or recently recreated instances."
+  type        = number
+  validation {
+    condition     = var.vm_mig_initial_delay_sec >= 1 && var.vm_mig_initial_delay_sec <= 3600
+    error_message = "The vm_mig_initial_delay_sec must be an integer between 1 and 3600, inclusive."
+  }
+}
+
+variable "vm_mig_timeout_sec" {
+  default     = 10
+  description = "How long to wait (in seconds) before a request is considered a failure."
+  type        = number
+  validation {
+    condition     = var.vm_mig_timeout_sec >= 1 && var.vm_mig_timeout_sec <= 300
+    error_message = "The vm_mig_initial_delay_sec must be an integer between 1 and 300 and must be lower than or equal to vm_mig_check_interval_sec."
+  }
+}
+
 variable "vm_mig_unhealthy_threshold" {
   default     = 6
-  description = "The number of sequential failed health check probe results for a backend to be considered unhealthy."
+  description = "The number of sequential failed health check probe results for a backend to be considered unhealthy. Unhealthy threshold must be an integer between 1 and 10, inclusive."
   type        = number
 }
 


### PR DESCRIPTION
## Background

#228 
[Jira TF-8869](https://hashicorp.atlassian.net/browse/TF-8869)

This branch adds variables for the `health_check` options available. Having these variables allows us to add more time to the health check to give TFE a bit more time to be installed and ready.

## How Has This Been Tested

Tests passed below . The one `destroy` failure was because of exceeding a GCP rate limit, ruining my perfect test moment. 