### PR TITLE
use tfe_init_legacy for Replicated installs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -177,7 +177,7 @@ module "settings" {
 # User data / cloud init used to install and configure TFE on instance(s)
 # -----------------------------------------------------------------------------
 module "tfe_init" {
-  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/tfe_init_legacy?ref=main"
+  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/tfe_init_replicated?ref=main"
 
   # TFE & Replicated Configuration data
   cloud                    = "google"

--- a/main.tf
+++ b/main.tf
@@ -177,7 +177,7 @@ module "settings" {
 # User data / cloud init used to install and configure TFE on instance(s)
 # -----------------------------------------------------------------------------
 module "tfe_init" {
-  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/tfe_init_legacy?ref=main"
+  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/tfe_init_legacy?ref=ah/5370"
 
   # TFE & Replicated Configuration data
   cloud                    = "google"

--- a/main.tf
+++ b/main.tf
@@ -177,7 +177,7 @@ module "settings" {
 # User data / cloud init used to install and configure TFE on instance(s)
 # -----------------------------------------------------------------------------
 module "tfe_init" {
-  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/tfe_init?ref=main"
+  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/tfe_init_legacy?ref=main"
 
   # TFE & Replicated Configuration data
   cloud                    = "google"

--- a/main.tf
+++ b/main.tf
@@ -177,7 +177,7 @@ module "settings" {
 # User data / cloud init used to install and configure TFE on instance(s)
 # -----------------------------------------------------------------------------
 module "tfe_init" {
-  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/tfe_init_legacy?ref=ah/tf-5370"
+  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/tfe_init_legacy?ref=main"
 
   # TFE & Replicated Configuration data
   cloud                    = "google"

--- a/main.tf
+++ b/main.tf
@@ -177,7 +177,7 @@ module "settings" {
 # User data / cloud init used to install and configure TFE on instance(s)
 # -----------------------------------------------------------------------------
 module "tfe_init" {
-  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/tfe_init_legacy?ref=ah/5370"
+  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/tfe_init_legacy?ref=ah/tf-5370"
 
   # TFE & Replicated Configuration data
   cloud                    = "google"


### PR DESCRIPTION
## Background

[Jira TF-5370](https://hashicorp.atlassian.net/browse/TF-5370)
[Jira TF-8611](https://hashicorp.atlassian.net/browse/TF-8611)

## How Has This Been Tested

- [x] I ran `ptfe-replicated` tests using [this branch](https://github.com/hashicorp/terraform-random-tfe-utility/pull/118) of the `tfe_init_legacy` module did not break the tests ([here](https://github.com/hashicorp/ptfe-replicated/actions/runs/6264601926)).