### PR TITLE
default consolidated_services to true

### DIFF
--- a/tests/standalone-external-rhel8-worker/variables.tf
+++ b/tests/standalone-external-rhel8-worker/variables.tf
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 variable "consolidated_services_enabled" {
-  default     = false
+  default     = true
   type        = bool
   description = "(Required) True if TFE uses consolidated services."
 }

--- a/tests/standalone-mounted-disk/variables.tf
+++ b/tests/standalone-mounted-disk/variables.tf
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 variable "consolidated_services_enabled" {
-  default     = false
+  default     = true
   type        = bool
   description = "(Required) True if TFE uses consolidated services."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -323,7 +323,7 @@ variable "capacity_memory" {
 }
 
 variable "consolidated_services_enabled" {
-  default     = false
+  default     = true
   type        = bool
   description = "(Required) True if TFE uses consolidated services."
 }


### PR DESCRIPTION
## Background
#270 
This is a followup PR so that the `consolidated_services_enabled` variable is defaulted to `true`. 