### PR TITLE
add disk_path to docker_compose

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -109,7 +109,7 @@ module "redis" {
 # Docker Compose File Config for TFE on instance(s) using Flexible Deployment Options
 # ------------------------------------------------------------------------------------
 module "docker_compose_config" {
-  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/docker_compose_config?ref=main"
+  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/docker_compose_config?ref=ah/disk_path"
   count  = var.is_replicated_deployment ? 0 : 1
 
   license_reporting_opt_out = var.license_reporting_opt_out
@@ -117,6 +117,7 @@ module "docker_compose_config" {
   capacity_concurrency      = var.capacity_concurrency
   capacity_cpu              = var.capacity_cpu
   capacity_memory           = var.capacity_memory
+  disk_path                 = local.enable_disk ? var.disk_path : null
   iact_subnets              = join(",", var.iact_subnet_list)
   iact_time_limit           = var.iact_subnet_time_limit
   operational_mode          = local.enable_active_active ? "active-active" : var.operational_mode
@@ -165,7 +166,7 @@ module "docker_compose_config" {
 # User data / cloud init used to install and configure TFE on instance(s) using Flexible Deployment Options
 # ----------------------------------------------------------------------------------------------------------
 module "tfe_init_fdo" {
-  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/tfe_init?ref=main"
+  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/tfe_init?ref=ah/disk_path"
   count  = var.is_replicated_deployment ? 0 : 1
 
   cloud             = "google"

--- a/main.tf
+++ b/main.tf
@@ -109,7 +109,7 @@ module "redis" {
 # Docker Compose File Config for TFE on instance(s) using Flexible Deployment Options
 # ------------------------------------------------------------------------------------
 module "docker_compose_config" {
-  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/docker_compose_config?ref=ah/disk_path"
+  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/docker_compose_config?ref=main"
   count  = var.is_replicated_deployment ? 0 : 1
 
   license_reporting_opt_out = var.license_reporting_opt_out
@@ -166,7 +166,7 @@ module "docker_compose_config" {
 # User data / cloud init used to install and configure TFE on instance(s) using Flexible Deployment Options
 # ----------------------------------------------------------------------------------------------------------
 module "tfe_init_fdo" {
-  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/tfe_init?ref=ah/disk_path"
+  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/tfe_init?ref=main"
   count  = var.is_replicated_deployment ? 0 : 1
 
   cloud             = "google"


### PR DESCRIPTION
## Background

Relates: https://github.com/hashicorp/terraform-random-tfe-utility/pull/135

While testing a backup, @miguelhrocha discovered that the disk_path was not set for FDO deployments. It had gone unnoticed since we had not done a backup test yet using these modules as it was using the default docker mount.

## How Has This Been Tested

Passing test below. Also, here you can see that the postgres data is on the instance.

<img width="423" alt="Screenshot 2023-11-15 at 10 09 31 AM" src="https://github.com/hashicorp/terraform-google-terraform-enterprise/assets/18335499/903ab394-d436-4e18-90ad-183f1c862935">
