### PR TITLE
[TF-10424] Upgrade google provider constraints to v5

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -372,15 +372,15 @@ module "vm_mig" {
   ] : []
   update_policy = var.enable_ssh ? [
     {
-      type = "OPPORTUNISTIC"
+      type                         = "OPPORTUNISTIC"
       instance_redistribution_type = "NONE"
-      minimal_action = var.is_replicated_deployment ? "RESTART" : "REPLACE"
-      max_unavailable_fixed = var.is_replicated_deployment ? 3 : null
-      max_surge_fixed = null
-      max_surge_percent = null
-      max_unavailable_percent = null
-      min_ready_sec = null
-      replacement_method = null
+      minimal_action               = var.is_replicated_deployment ? "RESTART" : "REPLACE"
+      max_unavailable_fixed        = var.is_replicated_deployment ? 3 : null
+      max_surge_fixed              = null
+      max_surge_percent            = null
+      max_unavailable_percent      = null
+      min_ready_sec                = null
+      replacement_method           = null
     }
   ] : []
 }

--- a/main.tf
+++ b/main.tf
@@ -375,9 +375,9 @@ module "vm_mig" {
       type = "OPPORTUNISTIC"
       instance_redistribution_type = "NONE"
       minimal_action = var.is_replicated_deployment ? "RESTART" : "REPLACE"
+      max_unavailable_fixed = var.is_replicated_deployment ? 1 : null
       max_surge_fixed = null
       max_surge_percent = null
-      max_unavailable_fixed = null
       max_unavailable_percent = null
       min_ready_sec = null
       replacement_method = null

--- a/main.tf
+++ b/main.tf
@@ -344,6 +344,7 @@ module "vm_mig" {
     timeout_sec         = var.vm_mig_timeout_sec
     type                = "https"
     unhealthy_threshold = var.vm_mig_unhealthy_threshold
+    enable_logging      = false
   }
   health_check_name = "${var.namespace}-tfe-health-check"
   hostname          = "${var.namespace}-tfe"

--- a/main.tf
+++ b/main.tf
@@ -322,14 +322,6 @@ module "vm_instance_template" {
   source_image   = var.vm_disk_source_image
   startup_script = base64decode(var.is_replicated_deployment ? module.tfe_init_replicated[0].tfe_userdata_base64_encoded : module.tfe_init_fdo[0].tfe_userdata_base64_encoded)
   subnetwork     = local.subnetwork.self_link
-
-  stateful_ips = var.enable_ssh ? [
-    {
-      interface_name = "nic0"
-      delete_rule    = "ON_PERMANENT_INSTANCE_DELETION"
-      is_external    = true
-    }
-  ] : []
 }
 
 module "vm_mig" {

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@
 
 module "project_factory_project_services" {
   source  = "terraform-google-modules/project-factory/google//modules/project_services"
-  version = "~> 11.2"
+  version = "~> 14.0"
 
   project_id = null
 
@@ -290,7 +290,7 @@ module "tfe_init_replicated" {
 
 module "vm_instance_template" {
   source  = "terraform-google-modules/vm/google//modules/instance_template"
-  version = "~> 7.1"
+  version = "~> 10.0"
 
   name_prefix = "${var.namespace}-tfe-template-"
 
@@ -334,7 +334,7 @@ module "vm_instance_template" {
 
 module "vm_mig" {
   source  = "terraform-google-modules/vm/google//modules/mig"
-  version = "~> 7.1"
+  version = "~> 10.0"
 
   instance_template = module.vm_instance_template.self_link
   region            = null
@@ -370,6 +370,13 @@ module "vm_mig" {
     }] : []
   )
   target_size = var.node_count
+  stateful_ips = var.enable_ssh ? [
+    {
+      interface_name = "nic0"
+      delete_rule    = "ON_PERMANENT_INSTANCE_DELETION"
+      is_external    = true
+    }
+  ] : []
 }
 
 resource "google_compute_address" "private" {

--- a/main.tf
+++ b/main.tf
@@ -322,6 +322,14 @@ module "vm_instance_template" {
   source_image   = var.vm_disk_source_image
   startup_script = base64decode(var.is_replicated_deployment ? module.tfe_init_replicated[0].tfe_userdata_base64_encoded : module.tfe_init_fdo[0].tfe_userdata_base64_encoded)
   subnetwork     = local.subnetwork.self_link
+
+  stateful_ips = [
+    {
+      interface_name = "nic0"
+      delete_rule    = "ON_PERMANENT_INSTANCE_DELETION"
+      is_external    = true
+    }
+  ]
 }
 
 module "vm_mig" {

--- a/main.tf
+++ b/main.tf
@@ -374,8 +374,8 @@ module "vm_mig" {
     {
       type = "OPPORTUNISTIC"
       instance_redistribution_type = "NONE"
-      minimal_action = var.is_replicated_deployment ? "RESTART" : "REPLACE"
-      max_unavailable_fixed = var.is_replicated_deployment ? 1 : null
+      minimal_action = null
+      max_unavailable_fixed = null
       max_surge_fixed = null
       max_surge_percent = null
       max_unavailable_percent = null

--- a/main.tf
+++ b/main.tf
@@ -374,8 +374,8 @@ module "vm_mig" {
     {
       type = "OPPORTUNISTIC"
       instance_redistribution_type = "NONE"
-      minimal_action = null
-      max_unavailable_fixed = null
+      minimal_action = var.is_replicated_deployment ? "RESTART" : "REPLACE"
+      max_unavailable_fixed = var.is_replicated_deployment ? 0 : null
       max_surge_fixed = null
       max_surge_percent = null
       max_unavailable_percent = null

--- a/main.tf
+++ b/main.tf
@@ -375,7 +375,7 @@ module "vm_mig" {
       type = "OPPORTUNISTIC"
       instance_redistribution_type = "NONE"
       minimal_action = var.is_replicated_deployment ? "RESTART" : "REPLACE"
-      max_unavailable_fixed = var.is_replicated_deployment ? 0 : null
+      max_unavailable_fixed = var.is_replicated_deployment ? 3 : null
       max_surge_fixed = null
       max_surge_percent = null
       max_unavailable_percent = null

--- a/main.tf
+++ b/main.tf
@@ -375,6 +375,12 @@ module "vm_mig" {
       type = "OPPORTUNISTIC"
       instance_redistribution_type = "NONE"
       minimal_action = var.is_replicated_deployment ? "RESTART" : "REPLACE"
+      max_surge_fixed = null
+      max_surge_percent = null
+      max_unavailable_fixed = null
+      max_unavailable_percent = null
+      min_ready_sec = null
+      replacement_method = null
     }
   ] : []
 }

--- a/main.tf
+++ b/main.tf
@@ -323,13 +323,13 @@ module "vm_instance_template" {
   startup_script = base64decode(var.is_replicated_deployment ? module.tfe_init_replicated[0].tfe_userdata_base64_encoded : module.tfe_init_fdo[0].tfe_userdata_base64_encoded)
   subnetwork     = local.subnetwork.self_link
 
-  stateful_ips = [
+  stateful_ips = var.enable_ssh ? [
     {
       interface_name = "nic0"
       delete_rule    = "ON_PERMANENT_INSTANCE_DELETION"
       is_external    = true
     }
-  ]
+  ] : []
 }
 
 module "vm_mig" {

--- a/main.tf
+++ b/main.tf
@@ -370,6 +370,13 @@ module "vm_mig" {
       is_external    = true
     }
   ] : []
+  update_policy = var.enable_ssh ? [
+    {
+      type = "OPPORTUNISTIC"
+      instance_redistribution_type = "NONE"
+      minimal_action = var.is_replicated_deployment ? "RESTART" : "REPLACE"
+    }
+  ] : []
 }
 
 resource "google_compute_address" "private" {

--- a/main.tf
+++ b/main.tf
@@ -363,14 +363,22 @@ module "vm_mig" {
     }] : []
   )
   target_size = var.node_count
-  stateful_ips = var.enable_ssh ? [
+  # When enabling public ssh access, the instances created by the mig will
+  # get a public IP address attached.
+  stateful_ips = var.enable_public_ssh_access ? [
     {
       interface_name = "nic0"
       delete_rule    = "ON_PERMANENT_INSTANCE_DELETION"
       is_external    = true
     }
   ] : []
-  update_policy = var.enable_ssh ? [
+
+  # When enabling stateful properties in a mig, the update_policy block is required.
+  # This block is used to specify how the mig should handle updates to the instances.
+  # In this case, we are using an opportunistic update policy to minimize the impact
+  # of updates to the instances when the mig is for replicated. When the mig is for
+  # FDO we use a replace update policy to ensure that the instances are replaced.
+  update_policy = var.enable_public_ssh_access ? [
     {
       type                         = "OPPORTUNISTIC"
       instance_redistribution_type = "NONE"

--- a/modules/database/versions.tf
+++ b/modules/database/versions.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.90"
+      version = "~> 5.0"
     }
 
     random = {

--- a/modules/load_balancer/versions.tf
+++ b/modules/load_balancer/versions.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.90"
+      version = "~> 5.0"
     }
   }
 }

--- a/modules/networking/versions.tf
+++ b/modules/networking/versions.tf
@@ -7,12 +7,12 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.90"
+      version = "~> 5.0"
     }
 
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.90"
+      version = "~> 5.0"
     }
   }
 }

--- a/modules/object_storage/versions.tf
+++ b/modules/object_storage/versions.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.90"
+      version = "~> 5.0"
     }
 
     random = {

--- a/modules/private_load_balancer/versions.tf
+++ b/modules/private_load_balancer/versions.tf
@@ -7,12 +7,12 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.90"
+      version = "~> 5.0"
     }
 
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.90"
+      version = "~> 5.0"
     }
   }
 }

--- a/modules/private_tcp_load_balancer/versions.tf
+++ b/modules/private_tcp_load_balancer/versions.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.90"
+      version = "~> 5.0"
     }
   }
 }

--- a/modules/redis/versions.tf
+++ b/modules/redis/versions.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.90"
+      version = "~> 5.0"
     }
 
     random = {

--- a/modules/service_accounts/versions.tf
+++ b/modules/service_accounts/versions.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.90"
+      version = "~> 5.0"
     }
 
     random = {

--- a/variables.tf
+++ b/variables.tf
@@ -128,8 +128,8 @@ variable "ssh_source_ranges" {
 }
 
 variable "enable_public_ssh_access" {
-  type    = bool
-  default = false
+  type        = bool
+  default     = false
   description = "A toggle to control the use of public SSH access to the compute instances. When enabled, the SSH port will be open to the public internet."
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -127,6 +127,11 @@ variable "ssh_source_ranges" {
   type        = list(string)
 }
 
+variable "enable_ssh" {
+  type = bool
+  default = false
+}
+
 variable "subnetwork" {
   default     = null
   description = "Pre-existing subnetwork self link"

--- a/variables.tf
+++ b/variables.tf
@@ -127,9 +127,10 @@ variable "ssh_source_ranges" {
   type        = list(string)
 }
 
-variable "enable_ssh" {
+variable "enable_public_ssh_access" {
   type    = bool
   default = false
+  description = "A toggle to control the use of public SSH access to the compute instances. When enabled, the SSH port will be open to the public internet."
 }
 
 variable "subnetwork" {

--- a/variables.tf
+++ b/variables.tf
@@ -128,7 +128,7 @@ variable "ssh_source_ranges" {
 }
 
 variable "enable_ssh" {
-  type = bool
+  type    = bool
   default = false
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -2,11 +2,11 @@
 # SPDX-License-Identifier: MPL-2.0
 
 terraform {
-  required_version = ">= 0.14"
+  required_version = "~> 1.6"
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.90"
+      version = "~> 5.0"
     }
   }
 }


### PR DESCRIPTION
## Background

This PR changes the root module and its submodules to upgrade the `hashicorp/google` and `hashicorp/google-beta` to rely on the v5 version.

The PR introduces the capability to attach public IPs to the instances created by the mig to enable ssh operations in the context of release testing. The variable that controls this flow is called `enable_public_ssh_access`.