### PR TITLE
add usage_reporting_opt_out variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -113,6 +113,7 @@ module "runtime_container_engine_config" {
   count  = var.is_replicated_deployment ? 0 : 1
 
   license_reporting_opt_out   = var.license_reporting_opt_out
+  usage_reporting_opt_out     = var.usage_reporting_opt_out
   hostname                    = local.common_fqdn
   capacity_concurrency        = var.capacity_concurrency
   capacity_cpu                = var.capacity_cpu

--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -99,8 +99,8 @@ resource "google_compute_global_address" "private_ip_address" {
 }
 
 resource "google_service_networking_connection" "private_vpc_connection" {
-  network = google_compute_network.tfe_vpc.self_link
-  service = "servicenetworking.googleapis.com"
-  deletion_policy = "ABANDON"
+  network                 = google_compute_network.tfe_vpc.self_link
+  service                 = "servicenetworking.googleapis.com"
+  deletion_policy         = "ABANDON"
   reserved_peering_ranges = [google_compute_global_address.private_ip_address.name]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -438,6 +438,12 @@ variable "license_reporting_opt_out" {
   description = "(Not needed if is_replicated_deployment is true) Whether to opt out of reporting licensing information to HashiCorp. Defaults to false."
 }
 
+variable "usage_reporting_opt_out" {
+  default     = false
+  type        = bool
+  description = "(Not needed if is_replicated_deployment is true) Whether to opt out of reporting usage information to HashiCorp. Defaults to false."
+}
+
 variable "operational_mode" {
   default     = "external"
   description = "A special string to control the operational mode of Terraform Enterprise. Valid values are: 'external' for External Services mode; 'disk' for Mounted Disk mode;."


### PR DESCRIPTION
This PR adds an additional optional variable to disable usage reporting to HashiCorp census service.