### PR TITLE
[TF-16084] Set max_unavailable_fixed in both FDO and replicated

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -389,7 +389,7 @@ module "vm_mig" {
       type                         = "OPPORTUNISTIC"
       instance_redistribution_type = "NONE"
       minimal_action               = var.is_replicated_deployment ? "RESTART" : "REPLACE"
-      max_unavailable_fixed        = var.is_replicated_deployment ? 3 : null
+      max_unavailable_fixed        = 3
       max_surge_fixed              = null
       max_surge_percent            = null
       max_unavailable_percent      = null


### PR DESCRIPTION
## Background

The Google provider set a limitation that either `max_unavailable_fixed` or `max_surge_fixed` has to be set, but at least one of them has to have a value. 

`max_unavailable_fixed` is already set in the case of Replicated, so I thought why not set it for FDO too?
