### PR TITLE
[TF-16084] Remove deletion_policy in google_service_networking_connection

### DIFF
--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -101,6 +101,5 @@ resource "google_compute_global_address" "private_ip_address" {
 resource "google_service_networking_connection" "private_vpc_connection" {
   network                 = google_compute_network.tfe_vpc.self_link
   service                 = "servicenetworking.googleapis.com"
-  deletion_policy         = "ABANDON"
   reserved_peering_ranges = [google_compute_global_address.private_ip_address.name]
 }


### PR DESCRIPTION
## Background

It is unclear to me why this is failing now, maybe Google did something that doesn't relect on the provider. However, we may not need this anymore due to a fix in the v5 provider:
https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/guides/version_5_upgrade#terraform-destroy-now-fully-deletes-the-resource-instead-of-abandoning


