### PR TITLE
Feature: Introduce variables database_host and database_password

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -5,7 +5,7 @@ locals {
   disk_device_name              = "sdb"
   enable_airgap                 = var.airgap_url == null && var.tfe_license_bootstrap_airgap_package_path != null
   enable_external               = var.operational_mode == "external" || var.operational_mode == "active-active"
-  enable_database_module        = local.enable_external
+  enable_database_module        = local.enable_external && var.database_host == null
   enable_disk                   = var.operational_mode == "disk"
   enable_networking_module      = var.network == null
   enable_object_storage_module  = local.enable_external
@@ -88,10 +88,10 @@ locals {
   database = try(
     module.database[0],
     {
-      dbname   = null
-      netloc   = null
-      password = null
-      user     = null
+      dbname   = var.database_name
+      netloc   = var.database_host
+      password = var.database_password
+      user     = var.database_user
     }
   )
 }

--- a/locals.tf
+++ b/locals.tf
@@ -8,8 +8,18 @@ locals {
   enable_database_module        = local.enable_external && var.database_host == null
   enable_disk                   = var.operational_mode == "disk"
   enable_networking_module      = var.network == null
-  enable_object_storage_module  = local.enable_external
   enable_redis_module           = var.operational_mode == "active-active"
+  activate_apis                 = compact([
+    "iam.googleapis.com",
+    "logging.googleapis.com",
+    "compute.googleapis.com",
+    (local.enable_database_module ? "sqladmin.googleapis.com" : null),
+    (local.enable_networking_module ? "networkmanagement.googleapis.com" : null),
+    (local.enable_networking_module ? "servicenetworking.googleapis.com" : null),
+    (local.enable_redis_module ? "redis.googleapis.com" : null),
+  ])
+  enable_object_storage_module  = local.enable_external
+
   service_networking_connection = try(module.networking[0].service_networking_connection, { network = var.network })
   subnetwork                    = try(module.networking[0].subnetwork, { self_link = var.subnetwork })
 

--- a/locals.tf
+++ b/locals.tf
@@ -2,14 +2,14 @@
 # SPDX-License-Identifier: MPL-2.0
 
 locals {
-  disk_device_name              = "sdb"
-  enable_airgap                 = var.airgap_url == null && var.tfe_license_bootstrap_airgap_package_path != null
-  enable_external               = var.operational_mode == "external" || var.operational_mode == "active-active"
-  enable_database_module        = local.enable_external && var.database_host == null
-  enable_disk                   = var.operational_mode == "disk"
-  enable_networking_module      = var.network == null
-  enable_redis_module           = var.operational_mode == "active-active"
-  activate_apis                 = compact([
+  disk_device_name         = "sdb"
+  enable_airgap            = var.airgap_url == null && var.tfe_license_bootstrap_airgap_package_path != null
+  enable_external          = var.operational_mode == "external" || var.operational_mode == "active-active"
+  enable_database_module   = local.enable_external && var.database_host == null
+  enable_disk              = var.operational_mode == "disk"
+  enable_networking_module = var.network == null
+  enable_redis_module      = var.operational_mode == "active-active"
+  activate_apis = compact([
     "iam.googleapis.com",
     "logging.googleapis.com",
     "compute.googleapis.com",
@@ -18,7 +18,7 @@ locals {
     (local.enable_networking_module ? "servicenetworking.googleapis.com" : null),
     (local.enable_redis_module ? "redis.googleapis.com" : null),
   ])
-  enable_object_storage_module  = local.enable_external
+  enable_object_storage_module = local.enable_external
 
   service_networking_connection = try(module.networking[0].service_networking_connection, { network = var.network })
   subnetwork                    = try(module.networking[0].subnetwork, { self_link = var.subnetwork })

--- a/main.tf
+++ b/main.tf
@@ -7,15 +7,7 @@ module "project_factory_project_services" {
 
   project_id = null
 
-  activate_apis = compact([
-    "iam.googleapis.com",
-    "logging.googleapis.com",
-    "compute.googleapis.com",
-    (local.enable_database_module ? "sqladmin.googleapis.com" : null),
-    (local.enable_networking_module ? "networkmanagement.googleapis.com" : null),
-    (local.enable_networking_module ? "servicenetworking.googleapis.com" : null),
-    (local.enable_redis_module ? "redis.googleapis.com" : null),
-  ])
+  activate_apis = local.activate_apis
   disable_dependent_services  = false
   disable_services_on_destroy = false
 }

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ module "project_factory_project_services" {
 
   project_id = null
 
-  activate_apis = local.activate_apis
+  activate_apis               = local.activate_apis
   disable_dependent_services  = false
   disable_services_on_destroy = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -153,13 +153,13 @@ variable "subnetwork" {
 # --------
 variable "database_host" {
   default     = null
-  description = "Database host"
+  description = "Optional: If you wish to connect TFE to an existing database, pass the host here."
   type        = string
 }
 
 variable "database_password" {
   default     = null
-  description = "Only needed if we provide a database host."
+  description = "Optional: If you wish to connect TFE to an existing database, pass the password here. Used together with database_host."
   type        = string
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -151,6 +151,18 @@ variable "subnetwork" {
 
 # DATABASE
 # --------
+variable "database_host" {
+  default     = null
+  description = "Database host"
+  type        = string
+}
+
+variable "database_password" {
+  default     = null
+  description = "Only needed if we provide a database host."
+  type        = string
+}
+
 variable "database_availability_type" {
   default     = "ZONAL"
   description = "Database Availability Type"


### PR DESCRIPTION
## Background
If we wish to deploy Terraform Enterprise with an external database, but reuse an existing database, we need to be able to pass both the host and the password. 

Context: https://hashicorp.atlassian.net/browse/TF-18440

## How Has This Been Tested

This has been tested in postgres failover tests, using a patroni cluster deployed separately, such as in this module: https://github.com/hashicorp/tf-onprem-dev-infra/blob/bc01989032fa5adc54635891506b88a97a5fa6be/modules/nikolasrieble/HAPG_docker_patroni.tf#L64
