### PR TITLE
Add GCP PostgreSQL IAM authentication support

### DIFF
--- a/examples/postgres-passwordless/README.md
+++ b/examples/postgres-passwordless/README.md
@@ -1,0 +1,87 @@
+# PostgreSQL Passwordless Authentication Example
+
+This example demonstrates deploying Terraform Enterprise with PostgreSQL IAM authentication (passwordless authentication) enabled on Google Cloud Platform.
+
+## About This Example
+
+This configuration deploys a single-node TFE instance in external mode with:
+
+- Google Cloud SQL PostgreSQL instance with IAM authentication enabled
+- Dedicated service account for database authentication
+- Cloud SQL Client IAM role assignment
+- PostgreSQL connection using IAM authentication instead of passwords
+
+## Prerequisites
+
+- GCP project with appropriate APIs enabled
+- DNS zone configured in Cloud DNS
+- SSL certificate available in Certificate Manager
+- Terraform Enterprise license file
+
+## Usage
+
+To run this example, you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Note that this example may create resources which can cost money. Run `terraform destroy` when you don't need these resources.
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.14 |
+| google | ~> 5.0 |
+| random | ~> 3.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| google | ~> 5.0 |
+| random | ~> 3.0 |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| dns_zone_name | The name of the DNS zone in which a record will be created. | `string` | n/a | yes |
+| existing_service_account_id | The ID of the logging service account to use for compute resources deployed. | `string` | `null` | no |
+| fqdn | The fully qualified domain name which will be assigned to the DNS record. | `string` | n/a | yes |
+| license_file | The local path to the Terraform Enterprise license. | `string` | n/a | yes |
+| project_id | The GCP project ID where resources will be created. | `string` | n/a | yes |
+| ssl_certificate_name | The name of an existing SSL certificate which will be used to authenticate connections to the load balancer. | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| database_service_account | The email of the service account used for PostgreSQL IAM authentication. |
+| health_check_url | The URL of the Terraform Enterprise health check endpoint. |
+| iact_notice | Login advice message. |
+| iact_url | IACT URL |
+| initial_admin_user_url | The URL of the initial admin user. |
+| login_url | The URL for the Terraform Enterprise login. |
+| tfe_url | The URL of the Terraform Enterprise application. |
+
+## IAM Authentication Details
+
+This example creates a dedicated service account for database authentication and grants it the `roles/cloudsql.client` role. The TFE application will use this service account to authenticate to PostgreSQL using Google Cloud IAM instead of traditional username/password authentication.
+
+The PostgreSQL connection will use the following authentication method:
+- Connection string includes `authtype=gcp_iam` parameter
+- No password is required or stored
+- Authentication is handled through Google Cloud IAM tokens
+
+## Security Benefits
+
+Using IAM authentication provides several security benefits:
+- No passwords to manage or rotate
+- Authentication tied to Google Cloud IAM
+- Automatic token refresh
+- Audit trail through Cloud Logging
+- Fine-grained access control through IAM roles

--- a/examples/postgres-passwordless/main.tf
+++ b/examples/postgres-passwordless/main.tf
@@ -1,0 +1,58 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+# Random String for unique names
+# ------------------------------
+resource "random_pet" "main" {
+  length = 1
+}
+
+# Store TFE License as secret
+# ---------------------------
+module "secrets" {
+  source = "../../fixtures/secrets"
+
+  license = {
+    id   = random_pet.main.id
+    path = var.license_file
+  }
+}
+
+# Create IAM service account for database authentication
+# ------------------------------------------------------
+resource "google_service_account" "tfe_database" {
+  account_id   = "${random_pet.main.id}-tfe-db"
+  display_name = "TFE Database Service Account"
+  description  = "Service account for TFE PostgreSQL IAM authentication"
+}
+
+# Grant Cloud SQL Client role to the service account
+resource "google_project_iam_member" "cloudsql_client" {
+  project = var.project_id
+  role    = "roles/cloudsql.client"
+  member  = "serviceAccount:${google_service_account.tfe_database.email}"
+}
+
+# Standalone External with PostgreSQL IAM Authentication
+# -------------------------------------------------------
+module "tfe" {
+  source = "../../"
+
+  distribution                       = "ubuntu"
+  dns_zone_name                      = var.dns_zone_name
+  existing_service_account_id        = var.existing_service_account_id
+  namespace                          = random_pet.main.id
+  node_count                         = 1
+  fqdn                               = var.fqdn
+  load_balancer                      = "PUBLIC"
+  ssl_certificate_name               = var.ssl_certificate_name
+  tfe_license_secret_id              = module.secrets.license_secret
+  vm_machine_type                    = "n1-standard-4"
+  operational_mode                   = "external"
+  enable_iam_database_authentication = true
+  iam_database_user                  = google_service_account.tfe_database.email
+
+  depends_on = [
+    google_project_iam_member.cloudsql_client
+  ]
+}

--- a/examples/postgres-passwordless/outputs.tf
+++ b/examples/postgres-passwordless/outputs.tf
@@ -1,0 +1,37 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+output "health_check_url" {
+  value       = module.tfe.health_check_url
+  description = "The URL of the Terraform Enterprise health check endpoint."
+}
+
+output "iact_notice" {
+  value       = "Once deployed, please follow this page to set the initial user up: https://www.terraform.io/docs/enterprise/install/automating-initial-user.html"
+  description = "Login advice message."
+}
+
+output "iact_url" {
+  value       = module.tfe.iact_url
+  description = "IACT URL"
+}
+
+output "initial_admin_user_url" {
+  value       = module.tfe.initial_admin_user_url
+  description = "The URL of the initial admin user."
+}
+
+output "login_url" {
+  value       = module.tfe.url
+  description = "The URL for the Terraform Enterprise login."
+}
+
+output "tfe_url" {
+  value       = module.tfe.url
+  description = "The URL of the Terraform Enterprise application."
+}
+
+output "database_service_account" {
+  value       = google_service_account.tfe_database.email
+  description = "The email of the service account used for PostgreSQL IAM authentication."
+}

--- a/examples/postgres-passwordless/terraform.tfvars.example
+++ b/examples/postgres-passwordless/terraform.tfvars.example
@@ -1,0 +1,7 @@
+namespace                   = "user-friendly-name"
+existing_service_account_id = "service-account-name"
+fqdn                        = "tfe.my.domain.com"
+ssl_certificate_name        = "certificate-name-xxxxxxxxxxxxxxxxxxxxx"
+dns_zone_name               = "my.domain.com"
+license_file                = "/files/license.rli"
+project_id                  = "my-gcp-project-id"

--- a/examples/postgres-passwordless/variables.tf
+++ b/examples/postgres-passwordless/variables.tf
@@ -1,0 +1,35 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+variable "dns_zone_name" {
+  description = "The name of the DNS zone in which a record will be created."
+  type        = string
+}
+
+variable "existing_service_account_id" {
+  default     = null
+  type        = string
+  description = "The ID of the logging service account to use for compute resources deployed."
+}
+
+variable "fqdn" {
+  description = "The fully qualified domain name which will be assigned to the DNS record."
+  type        = string
+}
+
+variable "license_file" {
+  type        = string
+  description = "The local path to the Terraform Enterprise license."
+}
+
+variable "project_id" {
+  description = "The GCP project ID where resources will be created."
+  type        = string
+}
+
+variable "ssl_certificate_name" {
+  description = <<-EOD
+  The name of an existing SSL certificate which will be used to authenticate connections to the load balancer.
+  EOD
+  type        = string
+}

--- a/examples/postgres-passwordless/versions.tf
+++ b/examples/postgres-passwordless/versions.tf
@@ -1,0 +1,17 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+terraform {
+  required_version = ">= 0.14"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/locals.tf
+++ b/locals.tf
@@ -104,9 +104,9 @@ locals {
       dbname                    = var.database_name
       netloc                    = var.database_host
       password                  = var.database_password
-      user                      = var.database_user
-      enable_iam_authentication = false
-      iam_user                  = null
+      user                      = var.enable_iam_database_authentication ? replace(var.iam_database_user, ".gserviceaccount.com", "") : var.database_user
+      enable_iam_authentication = var.enable_iam_database_authentication
+      iam_user                  = var.iam_database_user
     }
   )
 }

--- a/locals.tf
+++ b/locals.tf
@@ -101,10 +101,12 @@ locals {
     module.database[0],
     module.alloydb_database[0],
     {
-      dbname   = var.database_name
-      netloc   = var.database_host
-      password = var.database_password
-      user     = var.database_user
+      dbname                    = var.database_name
+      netloc                    = var.database_host
+      password                  = var.database_password
+      user                      = var.database_user
+      enable_iam_authentication = false
+      iam_user                  = null
     }
   )
 }

--- a/main.tf
+++ b/main.tf
@@ -123,7 +123,7 @@ module "redis" {
 # Docker Compose File Config for TFE on instance(s) using Flexible Deployment Options
 # ------------------------------------------------------------------------------------
 module "runtime_container_engine_config" {
-  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/runtime_container_engine_config?ref=main"
+  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/runtime_container_engine_config?ref=pravi-postgres-passwordless"
   count  = var.is_replicated_deployment ? 0 : 1
 
   license_reporting_opt_out   = var.license_reporting_opt_out

--- a/main.tf
+++ b/main.tf
@@ -403,7 +403,7 @@ module "vm_mig" {
       type                         = "OPPORTUNISTIC"
       instance_redistribution_type = "NONE"
       minimal_action               = var.is_replicated_deployment ? "RESTART" : "REPLACE"
-      max_unavailable_fixed        = 3
+      max_unavailable_fixed        = 4
       max_surge_fixed              = null
       max_surge_percent            = null
       max_unavailable_percent      = null

--- a/main.tf
+++ b/main.tf
@@ -123,7 +123,7 @@ module "redis" {
 # Docker Compose File Config for TFE on instance(s) using Flexible Deployment Options
 # ------------------------------------------------------------------------------------
 module "runtime_container_engine_config" {
-  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/runtime_container_engine_config?ref=pravi-postgres-passwordless"
+  source = "git::https://github.com/hashicorp/terraform-random-tfe-utility//modules/runtime_container_engine_config?ref=pravi/IND-5862"
   count  = var.is_replicated_deployment ? 0 : 1
 
   license_reporting_opt_out   = var.license_reporting_opt_out

--- a/main.tf
+++ b/main.tf
@@ -74,6 +74,8 @@ module "database" {
   labels                        = var.labels
   service_networking_connection = local.service_networking_connection
   postgres_version              = var.postgres_version
+  enable_iam_authentication     = var.enable_iam_database_authentication
+  iam_user_email                = var.iam_database_user
 
   depends_on = [
     module.project_factory_project_services
@@ -148,10 +150,10 @@ module "runtime_container_engine_config" {
   tls_ca_bundle_file = var.ca_certificate_secret_id != null ? "/etc/ssl/private/terraform-enterprise/bundle.pem" : null
 
   database_user       = local.database.user
-  database_password   = local.database.password
+  database_password   = local.database.enable_iam_authentication ? null : local.database.password
   database_host       = local.database.netloc
   database_name       = local.database.dbname
-  database_parameters = "sslmode=require"
+  database_parameters = local.database.enable_iam_authentication ? "sslmode=require&authtype=gcp_iam" : "sslmode=require"
 
   storage_type       = "google"
   google_bucket      = local.object_storage.bucket
@@ -254,8 +256,8 @@ module "settings" {
   pg_dbname       = local.database.dbname
   pg_netloc       = local.database.netloc
   pg_user         = local.database.user
-  pg_password     = local.database.password
-  pg_extra_params = "sslmode=require"
+  pg_password     = local.database.enable_iam_authentication ? null : local.database.password
+  pg_extra_params = local.database.enable_iam_authentication ? "sslmode=require&authtype=gcp_iam" : "sslmode=require"
 
   # Redis
   redis_host              = local.redis.host

--- a/main.tf
+++ b/main.tf
@@ -154,6 +154,7 @@ module "runtime_container_engine_config" {
   database_host       = local.database.netloc
   database_name       = local.database.dbname
   database_parameters = local.database.enable_iam_authentication ? "sslmode=require&authtype=gcp_iam" : "sslmode=require"
+  database_passwordless_gcp_use_default_credentials = local.database.enable_iam_authentication
 
   storage_type       = "google"
   google_bucket      = local.object_storage.bucket

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -58,7 +58,9 @@ resource "google_sql_user" "tfe" {
 resource "google_sql_user" "tfe_iam" {
   count = var.enable_iam_authentication ? 1 : 0
 
-  name     = var.iam_user_email
+  # Cloud SQL has a 63 character limit for usernames. For IAM service accounts,
+  # strip the .gserviceaccount.com suffix to create a shorter username
+  name     = replace(var.iam_user_email, ".gserviceaccount.com", "")
   instance = google_sql_database_instance.tfe.name
   type     = "CLOUD_IAM_SERVICE_ACCOUNT"
 

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -13,6 +13,7 @@ resource "google_sql_database_instance" "tfe" {
     tier              = var.machine_type
     availability_type = var.availability_type
     disk_size         = var.disk_size
+
     ip_configuration {
       ipv4_enabled    = false
       private_network = var.service_networking_connection.network
@@ -21,6 +22,11 @@ resource "google_sql_database_instance" "tfe" {
     backup_configuration {
       enabled    = var.backup_start_time == null ? false : true
       start_time = var.backup_start_time
+    }
+
+    database_flags {
+      name  = "cloudsql.iam_authentication"
+      value = var.enable_iam_authentication ? "on" : "off"
     }
 
     user_labels = var.labels
@@ -46,4 +52,15 @@ resource "google_sql_user" "tfe" {
 
   deletion_policy = "ABANDON"
   password        = random_string.postgres_password.result
+}
+
+# IAM database user for passwordless authentication
+resource "google_sql_user" "tfe_iam" {
+  count = var.enable_iam_authentication ? 1 : 0
+
+  name     = var.iam_user_email
+  instance = google_sql_database_instance.tfe.name
+  type     = "CLOUD_IAM_SERVICE_ACCOUNT"
+
+  deletion_policy = "ABANDON"
 }

--- a/modules/database/outputs.tf
+++ b/modules/database/outputs.tf
@@ -12,12 +12,24 @@ output "dbname" {
   description = "The name of the PostgreSQL database."
 }
 output "user" {
-  value = google_sql_user.tfe.name
+  value = var.enable_iam_authentication ? google_sql_user.tfe_iam[0].name : google_sql_user.tfe.name
 
   description = "The name of the PostgreSQL database user."
 }
 output "password" {
-  value = google_sql_user.tfe.password
+  value = var.enable_iam_authentication ? null : google_sql_user.tfe.password
 
   description = "The password of the PostgreSQL database user."
+}
+
+output "iam_user" {
+  value = var.enable_iam_authentication ? google_sql_user.tfe_iam[0].name : null
+
+  description = "The name of the IAM PostgreSQL database user."
+}
+
+output "enable_iam_authentication" {
+  value = var.enable_iam_authentication
+
+  description = "Whether IAM authentication is enabled for the database."
 }

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -52,3 +52,15 @@ variable "service_networking_connection" {
     network = string
   })
 }
+
+variable "enable_iam_authentication" {
+  default     = false
+  description = "Enable IAM database authentication for PostgreSQL database"
+  type        = bool
+}
+
+variable "iam_user_email" {
+  default     = null
+  description = "The email address of the Google service account to use for IAM database authentication. If not provided, the default compute engine service account will be used."
+  type        = string
+}

--- a/modules/service_accounts/main.tf
+++ b/modules/service_accounts/main.tf
@@ -22,7 +22,11 @@ data "google_service_account" "main" {
   account_id = var.existing_service_account_id
 }
 
+# Only create a service account key if we're creating a new service account.
+# When using an existing service account (e.g., with Workload Identity Federation),
+# the VM instance uses the attached service account identity directly.
 resource "google_service_account_key" "key" {
+  count              = var.existing_service_account_id == null ? 1 : 0
   service_account_id = local.service_account.name
 }
 

--- a/modules/service_accounts/outputs.tf
+++ b/modules/service_accounts/outputs.tf
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: MPL-2.0
 
 output "credentials" {
-  value = base64decode(google_service_account_key.key.private_key)
+  value = var.existing_service_account_id == null ? base64decode(google_service_account_key.key[0].private_key) : ""
 
-  description = "The private key of the service account."
+  description = "The private key of the service account. Empty when using an existing service account."
 }
 output "service_account" {
   value = var.existing_service_account_id == null ? google_service_account.main[0] : data.google_service_account.main[0]

--- a/variables.tf
+++ b/variables.tf
@@ -205,6 +205,18 @@ variable "postgres_version" {
   type        = string
 }
 
+variable "enable_iam_database_authentication" {
+  default     = false
+  description = "Enable IAM database authentication for PostgreSQL database"
+  type        = bool
+}
+
+variable "iam_database_user" {
+  default     = null
+  description = "The email address of the Google service account to use for IAM database authentication. If not provided, the default compute engine service account will be used."
+  type        = string
+}
+
 variable "region" {
   default     = "us-east4"
   description = "The region in which resources will be created."


### PR DESCRIPTION
- Add enable_iam_database_authentication variable for enabling IAM auth
- Add iam_database_user variable for service account email
- Update database module to support Cloud SQL IAM authentication
- Configure database_flags with cloudsql.iam_authentication=on
- Create IAM database user with CLOUD_IAM_SERVICE_ACCOUNT type
- Update database outputs to return appropriate user based on auth type
- Modify connection parameters to include authtype=gcp_iam for IAM auth
- Add postgres-passwordless example demonstrating IAM authentication
- Include service account creation and IAM role assignment in example
- Add comprehensive documentation for passwordless authentication


Relates : https://github.com/hashicorp/terraform-enterprise/pull/3177


## How Has This Been Tested

CI/CD: https://github.com/hashicorp/terraform-enterprise/actions/runs/18259243048/job/51984887571


